### PR TITLE
Add specific metadata for blog, events, posts, and topics pages

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,21 @@
 import { getSortedPostsData, formatTopicDisplay } from '@/lib/posts';
 import Link from 'next/link';
 import TopicTags from '@/components/TopicTags';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: "Blog | Craft & Code Club",
+  description: "Artigos sobre engenharia de software, System Design, Algoritmos, Estruturas de dados, DDD, melhores práticas e aprendizados da comunidade.",
+  keywords: ["Blog", "Artigos", "Desenvolvimento de Software", "Engenharia de Software", "System Design", "Algoritmos", "DDD"],
+  openGraph: {
+    title: "Blog | Craft & Code Club",
+    description: "Artigos sobre engenharia de software, System Design, Algoritmos, Estruturas de dados, DDD, melhores práticas e aprendizados da comunidade.",
+  },
+  twitter: {
+    title: "Blog | Craft & Code Club",
+    description: "Artigos sobre engenharia de software, System Design, Algoritmos, Estruturas de dados, DDD, melhores práticas e aprendizados da comunidade.",
+  }
+};
 
 export default function BlogPage() {
   const posts = getSortedPostsData();

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,5 +1,20 @@
 import { getEvents } from '@/lib/events';
 import type { Event } from '@/lib/events';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: "Eventos | Craft & Code Club",
+  description: "Participe dos nossos encontros sobre engenharia de software, System Design, Algoritmos, e muito mais.",
+  keywords: ["Eventos", "Workshops", "Meetups", "Comunidade", "Desenvolvimento de Software", "Algoritmos", "Estruturas de Dados", "System Design", "DDD"],
+  openGraph: {
+    title: "Eventos | Craft & Code Club",
+    description: "Participe dos nossos encontros sobre engenharia de software, System Design, Algoritmos, e muito mais.",
+  },
+  twitter: {
+    title: "Eventos | Craft & Code Club",
+    description: "Participe dos nossos encontros sobre engenharia de software, System Design, Algoritmos, e muito mais.",
+  }
+};
 
 export default async function EventsPage() {
   const { upcoming, past } = await getEvents();

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { getPostData, getSortedPostsData } from '@/lib/posts';
 import Link from 'next/link';
+import { Metadata } from 'next';
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -10,6 +11,29 @@ export async function generateStaticParams() {
   return posts.map((post) => ({
     id: post.id,
   }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const resolvedParams = await params;
+  const post = await getPostData(resolvedParams.id);
+  
+  return {
+    title: `${post.title} | Craft & Code Club`,
+    description: post.description,
+    keywords: [...post.topics, "Blog", "Artigo", "Desenvolvimento de Software", "Aprendizado", "Comunidade", "Algoritmos", "Estruturas de Dados", "System Design", "DDD"],
+    openGraph: {
+      title: `${post.title} | Craft & Code Club`,
+      description: post.description,
+      type: 'article',
+      publishedTime: post.date,
+      authors: post.authors?.map(author => author.name) || [],
+      tags: post.topics,
+    },
+    twitter: {
+      title: `${post.title} | Craft & Code Club`,
+      description: post.description
+    }
+  };
 }
 
 export default async function Post({ params }: Props) {

--- a/src/app/topics/[topic]/page.tsx
+++ b/src/app/topics/[topic]/page.tsx
@@ -2,6 +2,7 @@ import {getSortedPostsData, formatTopicDisplay, getAllTopics} from '@/lib/posts'
 import escapeHtml from 'escape-html';
 import Link from 'next/link';
 import TopicTags from '@/components/TopicTags';
+import { Metadata } from 'next';
 
 interface Props {
   params: Promise<{ topic: string }>;
@@ -19,6 +20,25 @@ export async function generateStaticParams() {
   return topics.map((topic) => ({
     topic: topic.replace(/\s+/g, '-').toLowerCase(),
   }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const resolvedParams = await params;
+  const topicTitle = resolvedParams.topic.charAt(0).toUpperCase() + resolvedParams.topic.slice(1).replace(/-/g, ' ');
+  
+  return {
+    title: `${topicTitle} | Craft & Code Club`,
+    description: `Artigos e recursos sobre ${topicTitle.toLowerCase()} da comunidade Craft & Code Club.`,
+    keywords: [topicTitle, "Desenvolvimento de Software", "Desenvolvimento", "Software", "Aprendizado", "Comunidade", "Algoritmos", "Estruturas de Dados", "System Design", "DDD"],
+    openGraph: {
+      title: `${topicTitle} | Craft & Code Club`,
+      description: `Artigos e recursos sobre ${topicTitle.toLowerCase()} da comunidade Craft & Code Club.`,
+    },
+    twitter: {
+      title: `${topicTitle} | Craft & Code Club`,
+      description: `Artigos e recursos sobre ${topicTitle.toLowerCase()} da comunidade Craft & Code Club.`,
+    }
+  };
 }
 
 export default async function TopicPage({ params }: Props) {


### PR DESCRIPTION
## Describe your changes

This pull request introduces metadata for SEO optimization across various pages of the application. The metadata includes titles, descriptions, keywords, and Open Graph and Twitter card information. The changes are applied to the blog, events, individual post, and topic pages.

## Issue number or link

#73 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] Implemented tests for new features.
- [x] I tested the features already implemented.
- [ ] Added usage examples in the readme.
