### PR TITLE
fix: update event date for book storage system design

### DIFF
--- a/_content/events/book-storage-system-design.md
+++ b/_content/events/book-storage-system-design.md
@@ -1,7 +1,7 @@
 ---
 title: "Clube do Livro: Armazenamento de Objetos Estilo S3 - System Design"
 description: "Seguindo o livro System Design Interview vol. 2. Vamos entrar no cap. 25 - Armazenamento de Objetos Estilo S3. Discutiremos como projetar um serviço de armazenamento de objetos em grande escala como o Amazon S3, explorando conceitos como versionamento, políticas de ciclo de vida, e replicação entre regiões."
-date: "2025-03-03"
+date: "2025-03-10"
 time: "21:00-22:30"
 location: "Online via Zoom"
 type: "online"


### PR DESCRIPTION
This pull request includes a small change to the `_content/events/book-storage-system-design.md` file. The change updates the event date from "2025-03-03" to "2025-03-10".