### PR TITLE
refactor: update bug report template to make fields optional

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -23,7 +23,7 @@ body:
       description: |
         What did you expect to happen?
     validations:
-      required: true
+      required: false
 
 
   - type: textarea
@@ -79,7 +79,7 @@ body:
       label: Targeted lib version
       placeholder: v1.0.0, v1.0.1, etc.
     validations:
-      required: true
+      required: false
 
 
   - type: input
@@ -87,7 +87,7 @@ body:
     attributes:
       label: Targeted Framework version
     validations:
-      required: true
+      required: false
 
 
   - type: input
@@ -96,4 +96,4 @@ body:
       label: Operating System and version
       placeholder: Windows 10, OSX Mojave, Ubuntu, AmazonLinux, etc.
     validations:
-      required: true
+      required: false


### PR DESCRIPTION
This pull request includes changes to the `.github/ISSUE_TEMPLATE/bug-report.yml` file to make certain fields optional instead of required. The most important changes include modifying the `description`, `Targeted lib version`, `Targeted Framework version`, and `Operating System and version` fields.

Changes to field requirements:

* `body:` in `.github/ISSUE_TEMPLATE/bug-report.yml`: Changed the `description` field's `required` validation from `true` to `false`.
* `body:` in `.github/ISSUE_TEMPLATE/bug-report.yml`: Changed the `Targeted lib version` field's `required` validation from `true` to `false`.
* `body:` in `.github/ISSUE_TEMPLATE/bug-report.yml`: Changed the `Targeted Framework version` field's `required` validation from `true` to `false`.
* `body:` in `.github/ISSUE_TEMPLATE/bug-report.yml`: Changed the `Operating System and version` field's `required` validation from `true` to `false`.
