### PR TITLE
fix: update event date for Topological Sorting algorithm

### DIFF
--- a/_content/events/dsa-topological-sorting.md
+++ b/_content/events/dsa-topological-sorting.md
@@ -1,7 +1,7 @@
 ---
 title: "Topological Sorting"
 description: "Explore o Topological Sorting, um algoritmo essencial para ordenar grafos direcionados acíclicos (DAGs). Compreenda seus fundamentos e aprenda a aplicá-lo para organizar dados e resolver problemas de dependência de forma eficiente."
-date: "2024-03-17"
+date: "2025-03-17"
 time: "21:00-22:30"
 location: "Online via Zoom"
 type: "online"


### PR DESCRIPTION
This pull request includes a minor update to the event details for the "Topological Sorting" event. The change updates the event date to reflect the new schedule.

* [`_content/events/dsa-topological-sorting.md`](diffhunk://#diff-9c3b99895799436853e8bd3d6ca59d6dbd5d56f49149233b313873c2ffe88b21L4-R4): Updated the event date from "2024-03-17" to "2025-03-17".
