### PR TITLE
fix: update event from Floyd Warshall to "Grafos: Dicas e Truques"

### DIFF
--- a/_content/events/dsa-floyd-warshall.md
+++ b/_content/events/dsa-floyd-warshall.md
@@ -1,9 +1,0 @@
----
-title: "Floyd Warshall"
-description: "Explore o Floyd Warshall, um dos algoritmos mais robustos para encontrar o caminho mínimo entre todos os pares de nós em um grafo. Entenda seus fundamentos e aprenda a aplicá-lo para resolver problemas de roteamento e otimização de redes de forma eficiente e precisa!"
-date: "2025-03-03"
-time: "21:00-22:30"
-location: "Online via Zoom"
-type: "online"
-registrationLink: "https://us06web.zoom.us/j/82173062389?pwd=hHBQsKgIup7tqHe0OeFhyToEzXJcko.1"
----

--- a/_content/events/dsa-floyd-warshall.md
+++ b/_content/events/dsa-floyd-warshall.md
@@ -1,7 +1,7 @@
 ---
 title: "Floyd Warshall"
 description: "Explore o Floyd Warshall, um dos algoritmos mais robustos para encontrar o caminho mínimo entre todos os pares de nós em um grafo. Entenda seus fundamentos e aprenda a aplicá-lo para resolver problemas de roteamento e otimização de redes de forma eficiente e precisa!"
-date: "2024-03-03"
+date: "2025-03-03"
 time: "21:00-22:30"
 location: "Online via Zoom"
 type: "online"

--- a/_content/events/dsa-graph-tips.md
+++ b/_content/events/dsa-graph-tips.md
@@ -1,0 +1,9 @@
+---
+title: "Grafos: Dicas e Truques"
+description: "Descubra dicas e truques para dominar grafos e aprimorar seus algoritmos na resolução de problemas complexos de forma prática e eficiente."
+date: "2025-03-03"
+time: "21:00-22:30"
+location: "Online via Zoom"
+type: "online"
+registrationLink: "https://us06web.zoom.us/j/82173062389?pwd=hHBQsKgIup7tqHe0OeFhyToEzXJcko.1"
+---


### PR DESCRIPTION
This pull request updates the event details for two files in the `_content/events` directory. The changes include modifying the details of an existing event and adding a new event.

Event details updates:

* [`_content/events/dsa-floyd-warshall.md`](diffhunk://#diff-ab349453fdd293a67a2662ec1599f094690b715932c514a9facc16cea167e59dL1-L9): Removed the event details for "Floyd Warshall."
* [`_content/events/dsa-graph-tips.md`](diffhunk://#diff-b55cfea99f2534b4536c37f4e40c22935f09c2dd328a4a43c5a7446082f951a6R1-R9): Added a new event titled "Grafos: Dicas e Truques" with its description, date, time, location, type, and registration link.
