### PR TITLE
feat: Add post link to event details and update UI for adding article links

### DIFF
--- a/_content/events/book-ad-click-event-aggregation.md
+++ b/_content/events/book-ad-click-event-aggregation.md
@@ -6,4 +6,5 @@ time: "21:00-22:30"
 location: "Online via Zoom"
 type: "online"
 recordingLink: "https://www.youtube.com/watch?v=L4wUa4dXHDk&list=PLl10TyPY67JhWj4Inb0vsz9R-fR197Plg"
+postLink: "https://craftcodeclub.io/posts/ad-click-event-aggregation"
 ---

--- a/_content/events/book-storage-system-design.md
+++ b/_content/events/book-storage-system-design.md
@@ -6,4 +6,5 @@ time: "20:00-21:30"
 location: "Online via Zoom"
 type: "online"
 recordingLink: "https://www.youtube.com/watch?v=E1oETLSeD3w"
+postLink: "https://craftcodeclub.io/posts/2025-04-07-system-design-object-storage-like-s3"
 ---

--- a/_content/events/dsa-a-star.md
+++ b/_content/events/dsa-a-star.md
@@ -6,4 +6,5 @@ time: "21:00-22:30"
 location: "Online via Zoom"
 type: "online"
 recordingLink: "https://www.youtube.com/watch?v=0PYx7erkdXo"
+postLink: "https://craftcodeclub.io/posts/dsa-a-star"
 ---

--- a/_content/events/dsa-graph-tips.md
+++ b/_content/events/dsa-graph-tips.md
@@ -5,4 +5,5 @@ date: "2025-03-10"
 time: "21:00-22:30"
 location: "Online via Zoom"
 type: "online"
+postLink: "https://93487814.blog-c3.pages.dev/posts/dsa-graph-tips"
 ---

--- a/_content/events/dsa-graphs-bellman-ford.md
+++ b/_content/events/dsa-graphs-bellman-ford.md
@@ -6,4 +6,5 @@ time: "21:00-22:30"
 location: "Online via Zoom"
 type: "online"
 recordingLink: "https://www.youtube.com/watch?v=0GcXgQTpYcE"
+postLink: "https://craftcodeclub.io/posts/dsa-bellman-ford"
 ---

--- a/_content/events/dsa-graphs-dijkstra.md
+++ b/_content/events/dsa-graphs-dijkstra.md
@@ -6,4 +6,5 @@ time: "21:00-22:30"
 location: "Online via Zoom"
 type: "online"
 recordingLink: "https://www.youtube.com/watch?v=b4kWEWtCVzA&list=PLl10TyPY67Jgbh4QdRlRKr-7PjB9i5hWg"
+postLink: "https://craftcodeclub.io/posts/dsa-dijkstra"
 ---

--- a/_content/events/dsa-topological-sorting.md
+++ b/_content/events/dsa-topological-sorting.md
@@ -6,4 +6,5 @@ time: "21:00-22:30"
 location: "Online via Zoom"
 type: "online"
 recordingLink: "https://www.youtube.com/watch?v=4fTjXqcMFtk"
+postLink: "https://craftcodeclub.io/posts/dsa-topological-sorting"
 ---

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -218,16 +218,28 @@ export default async function EventPage({ params }: Props) {
                       </a>
                     </div>
                   ) : (
-                    event.recordingLink && (
-                      <a
-                        href={event.recordingLink}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="block w-full text-center px-4 py-2 rounded-md transition-colors bg-purple-600 dark:bg-purple-500 hover:bg-purple-700 dark:hover:bg-purple-600 text-white"
-                      >
-                        Assistir Gravação
-                      </a>
-                    )
+                    <div className="flex gap-3">
+                      { event.recordingLink && (
+                        <a
+                          href={event.recordingLink}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="block w-full text-center px-4 py-2 rounded-md transition-colors bg-purple-600 dark:bg-purple-500 hover:bg-purple-700 dark:hover:bg-purple-600 text-white"
+                        >
+                          Assistir Gravação
+                        </a>
+                      ) }
+                      { event.postLink && (
+                        <a
+                          href={event.postLink}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="block w-full text-center px-4 py-2 rounded-md transition-colors bg-purple-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 text-white"
+                        >
+                          Ler Artigo
+                        </a>
+                      ) }
+                    </div>
                   )}
                 </div>
               </div>

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -14,6 +14,7 @@ export interface Event {
   type: string;
   registrationLink?: string;
   recordingLink?: string;
+  postLink?: string;
   speakers?: string[];
 }
 


### PR DESCRIPTION
This PR adds the article link prop to the events model and in the UI presentation, so that we can have a button "Ler Artigo" in the event details page/UI too.

![image](https://github.com/user-attachments/assets/c04d2d85-ac4e-4510-8222-aa6c585fb438)
