### PR TITLE
content/schedule: Adjust all the next events with a +1 week

### DIFF
--- a/_content/events/2025-04-21-dsa-mst.md
+++ b/_content/events/2025-04-21-dsa-mst.md
@@ -1,7 +1,7 @@
 ---
 title: "MST - Árvores Geradoras Mínimas na Prática"
 description: "Entenda como funcionam as Árvores Geradoras Mínimas, suas aplicações no mundo real e os principais algoritmos como Kruskal e Prim."
-date: "2025-04-14"
+date: "2025-04-21"
 time: "20:00-21:30"
 location: "Online via Zoom"
 type: "online"

--- a/_content/events/2025-04-28-book-realtime-gaming-leaderboard.md
+++ b/_content/events/2025-04-28-book-realtime-gaming-leaderboard.md
@@ -1,7 +1,7 @@
 ---
 title: "Clube do Livro: Real-time Gaming Leaderboard: Desafios e Soluções"
 description: "Descubra os desafios e soluções para criar leaderboards em real-time que medem desempenho e engajamento nos jogos."
-date: "2025-04-21"
+date: "2025-04-28"
 time: "20:00-21:30"
 location: "Online via Zoom"
 type: "online"

--- a/_content/events/2025-05-05-dsa-backtracking.md
+++ b/_content/events/2025-05-05-dsa-backtracking.md
@@ -1,7 +1,7 @@
 ---
 title: "Explorando Backtracking: Algoritmo e Aplicações"
 description: "Neste encontro, vamos entender como funciona o backtracking, amplamente utilizado para resolver problemas como geração de permutações, quebra-cabeças, Sudoku e muito mais. Veja como essa técnica permite explorar múltiplas possibilidades de forma estruturada e eficiente."
-date: "2025-04-28"
+date: "2025-05-05"
 time: "20:00-21:30"
 location: "Online via Zoom"
 type: "online"

--- a/_content/events/2025-05-12-book-payment-system.md
+++ b/_content/events/2025-05-12-book-payment-system.md
@@ -1,7 +1,7 @@
 ---
 title: "Clube do Livro: Payment System — Como Projetar Sistemas de Pagamento Escaláveis e Seguros"
 description: "Explore os bastidores dos sistemas de pagamento usados em grandes plataformas como Amazon e Stripe. Vamos discutir design de sistemas, reconciliação, segurança, consistência, idempotência e muito mais."
-date: "2025-05-05"
+date: "2025-05-12"
 time: "20:00-21:30"
 location: "Online via Zoom"
 type: "online"

--- a/_content/events/2025-05-26-digital-wallet.md
+++ b/_content/events/2025-05-26-digital-wallet.md
@@ -1,7 +1,7 @@
 ---
 title: "Clube do Livro: Digital Wallet — Alta Performance, Transações Distribuídas e Event Sourcing"
 description: "Vamos explorar como projetar carteiras digitais com suporte a 1 milhão de transações por segundo, utilizando técnicas como transações distribuídas (Saga, TC/C) e event sourcing com CQRS."
-date: "2025-05-19"
+date: "2025-05-26"
 time: "20:00-21:30"
 location: "Online via Zoom"
 type: "online"


### PR DESCRIPTION
2025-04-14 → 2025-04-21 (dsa-mst)
2025-04-21 → 2025-04-28 (book-realtime-gaming-leaderboard)
2025-04-28 → 2025-05-05 (dsa-backtracking)
2025-05-05 → 2025-05-12 (book-payment-system)
2025-05-19 → 2025-05-26 (digital-wallet)