### PR TITLE
chore: add launch configuration for fullstack React application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ yarn-error.log*
 next-env.d.ts
 .idea
 .idea/*
+.data

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,39 @@
+{
+    "version": "0.2.0",
+    "compounds": [
+        {
+            "name": "fullstack: react",
+            "configurations": [
+                "server: next",
+                "client: chrome"
+            ],
+            "stopAll": true
+        }
+    ],
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "client: chrome",
+            "url": "http://localhost:3000",
+            "webRoot": "${workspaceFolder}",
+            "sourceMapPathOverrides": {
+                "webpack:///src/*": "${webRoot}/src/*"
+            },
+            "userDataDir": "${workspaceFolder}/.data/chrome-debug-profile",
+            "runtimeArgs": [
+                "--disable-session-crashed-bubble"
+            ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "server: next",
+            "outputCapture": "std",
+            "program": "${workspaceFolder}/node_modules/next/dist/bin/next",
+            "args": [
+                "dev"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3db8c8bf-fa99-4138-892f-e4a738d71a99)

This pull request adds a new debugging configuration for VS Code to streamline full-stack development with React and Next.js. The configuration supports debugging both the client (in Chrome) and the server (Next.js) simultaneously.

Debugging configuration updates:

* [`.vscode/launch.json`](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945R1-R39): Added a compound configuration named `fullstack: react` to enable simultaneous debugging of the client (`client: chrome`) and server (`server: next`). The client configuration launches Chrome with a specified URL and source map path overrides, while the server configuration runs the Next.js development server.

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] Implemented tests for new features.
- [x] I tested the features already implemented.
- [ ] Added usage examples in the readme.
