### PR TITLE
Add keyword generation for events and posts

### DIFF
--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -3,6 +3,7 @@ import { getEvent, getEvents } from '@/lib/events';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import EventDetailClient from '@/components/EventDetailClient';
+import { buildKeywords, DEFAULT_EVENT_KEYWORDS } from '@/lib/seo';
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -29,6 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: `${event.title} | Craft & Code Club`,
     description: event.description,
+    keywords: buildKeywords(event.tags ?? [], DEFAULT_EVENT_KEYWORDS),
     openGraph: {
       title: `${event.title} | Craft & Code Club`,
       description: event.description

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -4,6 +4,7 @@ import { Metadata } from 'next';
 import FocusModeWrapper from '@/components/FocusModeWrapper';
 import { FocusModeProvider } from '@/components/FocusModeContext';
 import AuthorAvatar from '@/components/AuthorAvatar';
+import { buildKeywords, DEFAULT_POST_KEYWORDS } from '@/lib/seo';
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -19,11 +20,11 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const resolvedParams = await params;
   const post = await getPostData(resolvedParams.id);
-  
+
   return {
     title: `${post.title} | Craft & Code Club`,
     description: post.description,
-    keywords: [...post.topics.map(topic => topic.name), "Blog", "Artigo", "Desenvolvimento de Software", "Aprendizado", "Comunidade", "Algoritmos", "Estruturas de Dados", "System Design", "DDD"],
+    keywords: buildKeywords([...(post.keywords ?? []), ...post.topics.map(topic => topic.name)], DEFAULT_POST_KEYWORDS),
     openGraph: {
       title: `${post.title} | Craft & Code Club`,
       description: post.description,
@@ -73,7 +74,7 @@ export default async function Post({ params }: Props) {
         <div className="prose dark:prose-invert prose-lg max-w-none">
           <div dangerouslySetInnerHTML={{ __html: post.contentHtml }} />
         </div>
-        
+
         {authors.length > 0 && (
           <footer className="mt-12 pt-8 border-t border-gray-200 dark:border-gray-700">
             <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">Sobre os Autores</h2>
@@ -81,10 +82,10 @@ export default async function Post({ params }: Props) {
                 <div key={index} className="flex items-center space-x-3">
                   <AuthorAvatar author={author} />
                   {author.link ? (
-                    <a 
+                    <a
                       href={author.link}
                       target="_blank"
-                      rel="noopener noreferrer" 
+                      rel="noopener noreferrer"
                       className="text-gray-900 dark:text-white font-medium hover:text-blue-600 dark:hover:text-blue-400"
                     >
                       {author.name}
@@ -100,4 +101,4 @@ export default async function Post({ params }: Props) {
       </FocusModeWrapper>
     </FocusModeProvider>
   );
-} 
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -91,7 +91,7 @@ export async function getPostData(id: string): Promise<BlogPost> {
     date: data.date,
     description: data.description,
     topics: mountTopics(data.topics, topicsMetadata),
-    keywords: data.keywords ?? [],
+    keywords: Array.isArray(data.keywords) ? data.keywords : [],
     authors: data.authors,
   };
 }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -50,7 +50,7 @@ export function getSortedPostsData(): Omit<BlogPost, 'contentHtml'>[] {
       date: data.date,
       description: data.description,
       topics: mountTopics(data.topics, topicsMetadata),
-      keywords: data.keywords ?? [],
+      keywords: Array.isArray(data.keywords) ? data.keywords : data.keywords ? [data.keywords] : [],
     };
   });
   // Sort posts by date

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -20,6 +20,7 @@ export type BlogPost = {
   date: string;
   description: string;
   topics: Topic[];
+  keywords?: string[];
   contentHtml: string;
   authors?: Array<{
     name: string;
@@ -49,6 +50,7 @@ export function getSortedPostsData(): Omit<BlogPost, 'contentHtml'>[] {
       date: data.date,
       description: data.description,
       topics: mountTopics(data.topics, topicsMetadata),
+      keywords: data.keywords ?? [],
     };
   });
   // Sort posts by date
@@ -89,6 +91,7 @@ export async function getPostData(id: string): Promise<BlogPost> {
     date: data.date,
     description: data.description,
     topics: mountTopics(data.topics, topicsMetadata),
+    keywords: data.keywords ?? [],
     authors: data.authors,
   };
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,38 @@
+export const DEFAULT_POST_KEYWORDS = [
+  'Blog',
+  'Artigo',
+  'Desenvolvimento de Software',
+  'Aprendizado',
+  'Comunidade',
+  'Algoritmos',
+  'Estruturas de Dados',
+  'System Design',
+  'DDD',
+];
+
+export const DEFAULT_EVENT_KEYWORDS = [
+  'Eventos',
+  'Workshops',
+  'Meetups',
+  'Comunidade',
+  'Desenvolvimento de Software',
+  'Algoritmos',
+  'Estruturas de Dados',
+  'System Design',
+  'DDD',
+];
+
+export function buildKeywords(specific: string[], defaults: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const keyword of [...specific, ...defaults]) {
+    const normalized = keyword.toLowerCase();
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      result.push(keyword);
+    }
+  }
+
+  return result;
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -26,7 +26,10 @@ export function buildKeywords(specific: string[], defaults: string[]): string[] 
   const seen = new Set<string>();
   const result: string[] = [];
 
-  for (const keyword of [...specific, ...defaults]) {
+  for (const rawKeyword of [...specific, ...defaults]) {
+    const keyword = rawKeyword.trim();
+    if (!keyword) continue;
+
     const normalized = keyword.toLowerCase();
     if (!seen.has(normalized)) {
       seen.add(normalized);


### PR DESCRIPTION
Enhance SEO capabilities by implementing keyword generation for events and posts. This change allows for more relevant keywords to be included in the metadata, improving search visibility.

### Migration

- No migration steps required.

### Testing

- Verified that keywords are generated correctly for both events and posts.

- Ensured that existing functionality remains unaffected.

### Configuration

- No new configuration or environment variables introduced.

### Security

- No security implications identified.

Closes https://github.com/craft-code-club/blog-c3/issues/106


