### PR TITLE
docs: add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+Guidance for AI agents working in this repository.
+
+## Project overview
+
+Craft & Code Club Blog (`blog-v2`) is a **Next.js 16 static-export** community site. Content lives in `_content/` as Markdown/YAML; there is no backend, database, or required environment variables.
+
+## Cursor Cloud specific instructions
+
+### Services
+
+| Service | Required | Notes |
+|---------|----------|-------|
+| Next.js dev server | Yes | Primary development workflow |
+| Docker/nginx | No | Optional production-like static serving |
+| Database/API | No | Not used |
+
+### Commands
+
+Standard commands are in `package.json` and `README.md`:
+
+- **Install:** `npm ci` (preferred; matches CI) or `npm install`
+- **Dev:** `npm run dev` → http://localhost:3000 (uses Turbopack)
+- **Build:** `npm run build` → static output in `out/`
+- **Roadmap validation:** `npx tsx scripts/validate-roadmap.ts`
+
+### Lint caveat
+
+`npm run lint` (`next lint`) **does not work** on Next.js 16.2.7 — the `lint` subcommand was removed from the Next.js CLI. CI only runs `npm run build`, not lint. Do not treat lint failure as a blocker unless the script is updated upstream.
+
+### Tests
+
+There is no `npm test` script and no unit test suite in this repo. Verification is via `npm run build` and the roadmap validator.
+
+### Node version
+
+CI uses **Node 20** (`.github/workflows/cloudflare-pages-deploy.yml`). Node 22 also works for local dev/build.
+
+### Docker note
+
+`docker-compose.yml` references `Dockerfile`, but the repo file is named `dockerfile` (lowercase). On Linux this can break `docker compose up --build`. Prefer `npm run dev` for local development.
+
+### Key routes to smoke-test
+
+`/`, `/blog`, `/posts/dsa-skip-list`, `/events`, `/roadmap/dsa`, `/topics`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with project context and Cursor Cloud-specific development instructions discovered during environment setup.

## Contents

- Project overview (Next.js static-export blog, no backend)
- Dev commands reference (`npm ci`, `npm run dev`, `npm run build`, roadmap validator)
- Lint caveat: `next lint` removed in Next.js 16; CI only runs build
- Node version note (CI uses Node 20)
- Docker filename case-sensitivity gotcha on Linux
- Key routes for smoke-testing

## Verification performed

- `npm ci` — dependencies installed
- `npm run build` — 117 static pages generated successfully
- `npx tsx scripts/validate-roadmap.ts` — roadmap YAML valid
- `npm run dev` — dev server on http://localhost:3000
- Browser smoke test: homepage, blog listing, post detail, DSA roadmap, events

<a href="https://cursor.com/agents/bc-85403c53-1ad8-463a-a75a-e5005778e059/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog-dev-environment-demo.mp4"><img src="https://cursor.com/artifacts/c/art-aeb2e475-238f-4a2b-8722-47f8d0d27e9f" alt="blog-dev-environment-demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85403c53-1ad8-463a-a75a-e5005778e059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85403c53-1ad8-463a-a75a-e5005778e059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

