### PR TITLE
Add Excalidraw links to event pages

### DIFF
--- a/.github/chatmodes/events-creator.chatmode.md
+++ b/.github/chatmodes/events-creator.chatmode.md
@@ -19,6 +19,7 @@ type: "online"
 banner: "banner-file-name.png"
 recordingLink: "https://www.youtube.com/watch?v=XXXXXXXXXXX"
 postLink: "https://craftcodeclub.io/posts/post-slug"
+excalidrawLink: "https://link.excalidraw.com/l/XXXXXXXXXXX"
 registrationLink: "https://link-to-registration.com"
 speakers:
   - name: "Speaker Name"
@@ -37,6 +38,7 @@ speakers:
 ## Optional Properties:
 - **recordingLink**: Link to the event recording on YouTube (string)
 - **postLink**: Link to the related blog post (string)
+- **excalidrawLink**: Link to the related Excalidraw board (string)
 - **registrationLink**: Link to the event registration page (string)
 - **speakers**: List of speakers, each with a `name` property (array of objects)
 

--- a/_content/events/book-club-ddia-chapter-1.md
+++ b/_content/events/book-club-ddia-chapter-1.md
@@ -11,6 +11,7 @@ banner: "book-club-ddia.png"
 registrationLink: "https://discord.gg/cqF9THUfnN"
 recordingLink: "https://youtu.be/53TFZSe-IGw"
 postLink: "https://craftcodeclub.io/posts/ddia-trade-offs-arquitetura-de-sistemas"
+excalidrawLink: "https://link.excalidraw.com/l/ADMgGFVWISx/9G9VQCCv2rL"
 tags:
   - "book-club"
   - "ddia"

--- a/_content/events/book-club-ddia-chapter-2-part1.md
+++ b/_content/events/book-club-ddia-chapter-2-part1.md
@@ -11,6 +11,7 @@ banner: "book-club-ddia.png"
 registrationLink: "https://discord.gg/cqF9THUfnN"
 recordingLink: "https://youtube.com/live/1FyvJh315Xk"
 sessionLink: "https://us06web.zoom.us/j/81900343896"
+excalidrawLink: "https://link.excalidraw.com/l/ADMgGFVWISx/1ncjQemuKVK"
 tags:
   - "book-club"
   - "ddia"

--- a/docs/events.md
+++ b/docs/events.md
@@ -16,6 +16,7 @@ Campos suportados hoje:
 - `registrationLink` (string, opcional): link de inscricao/participacao.
 - `recordingLink` (string, opcional): link da gravação ou live do evento.
 - `postLink` (string, opcional): link de artigo relacionado.
+- `excalidrawLink` (string, opcional): link do quadro Excalidraw relacionado ao evento.
 - `speakers` (string[], opcional): lista de palestrantes.
 - `tags` (string[], opcional): tags do evento.
 - `isLive` (boolean, opcional): campo extra (nao usado pelo site hoje); usado por automacoes externas (ex.: bot do Discord).
@@ -91,6 +92,7 @@ Comportamento da pagina de detalhe
 
 - Mostra `Assistir Gravacao` quando `recordingLink` existe.
 - Mostra `Ler Artigo` quando `postLink` existe.
+- Mostra `Abrir Excalidraw` quando `excalidrawLink` existe; o link abre em nova aba.
 
 #### Evento hoje
 

--- a/docs/examples/event-example.md
+++ b/docs/examples/event-example.md
@@ -11,6 +11,7 @@ banner: "event-banner.png" # Opcional
 registrationLink: "https://www.meetup.com/platform-engineers-nyc"
 recordingLink: "https://www.youtube.com/watch?v=E1oETLSeD3w"
 postLink: "https://craftcodeclub.io/posts/sd-object-storage-like-s3"
+excalidrawLink: "https://link.excalidraw.com/l/example/example"
 tags:
   - "book-club"
   - "ddia"

--- a/src/components/EventDetailClient.tsx
+++ b/src/components/EventDetailClient.tsx
@@ -162,7 +162,7 @@ export default function EventDetailClient({ event, nextEvents }: Props) {
                   </a>
                 </div>
               ) : (
-                <div className="flex gap-3">
+                <div className="flex flex-col sm:flex-row gap-3">
                   {event.recordingLink && (
                     <a
                       href={event.recordingLink}
@@ -181,6 +181,16 @@ export default function EventDetailClient({ event, nextEvents }: Props) {
                       className="block w-full text-center px-4 py-2 rounded-md transition-colors bg-purple-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 text-white"
                     >
                       Ler Artigo
+                    </a>
+                  )}
+                  {event.excalidrawLink && (
+                    <a
+                      href={event.excalidrawLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block w-full text-center px-4 py-2 rounded-md transition-colors bg-orange-600 dark:bg-orange-500 hover:bg-orange-700 dark:hover:bg-orange-600 text-white"
+                    >
+                      Abrir Excalidraw
                     </a>
                   )}
                 </div>

--- a/src/components/EventDetailClient.tsx
+++ b/src/components/EventDetailClient.tsx
@@ -168,7 +168,7 @@ export default function EventDetailClient({ event, nextEvents }: Props) {
                       href={event.recordingLink}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="block w-full text-center px-4 py-2 rounded-md transition-colors bg-purple-600 dark:bg-purple-500 hover:bg-purple-700 dark:hover:bg-purple-600 text-white"
+                      className="sm:flex-1 flex items-center justify-center text-center px-4 py-2 rounded-md transition-colors bg-purple-600 dark:bg-purple-500 hover:bg-purple-700 dark:hover:bg-purple-600 text-white"
                     >
                       Assistir Gravação
                     </a>
@@ -178,7 +178,7 @@ export default function EventDetailClient({ event, nextEvents }: Props) {
                       href={event.postLink}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="block w-full text-center px-4 py-2 rounded-md transition-colors bg-purple-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 text-white"
+                      className="sm:flex-1 flex items-center justify-center text-center px-4 py-2 rounded-md transition-colors bg-purple-600 dark:bg-purple-500 hover:bg-purple-700 dark:hover:bg-purple-600 text-white"
                     >
                       Ler Artigo
                     </a>
@@ -188,7 +188,7 @@ export default function EventDetailClient({ event, nextEvents }: Props) {
                       href={event.excalidrawLink}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="block w-full text-center px-4 py-2 rounded-md transition-colors bg-purple-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 text-white"
+                      className="sm:flex-1 flex items-center justify-center text-center px-4 py-2 rounded-md transition-colors bg-purple-600 dark:bg-purple-500 hover:bg-purple-700 dark:hover:bg-purple-600 text-white"
                     >
                       Abrir Excalidraw
                     </a>

--- a/src/components/EventDetailClient.tsx
+++ b/src/components/EventDetailClient.tsx
@@ -188,7 +188,7 @@ export default function EventDetailClient({ event, nextEvents }: Props) {
                       href={event.excalidrawLink}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="block w-full text-center px-4 py-2 rounded-md transition-colors bg-orange-600 dark:bg-orange-500 hover:bg-orange-700 dark:hover:bg-orange-600 text-white"
+                      className="block w-full text-center px-4 py-2 rounded-md transition-colors bg-purple-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 text-white"
                     >
                       Abrir Excalidraw
                     </a>

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -16,6 +16,7 @@ export interface Event {
   registrationLink?: string;
   recordingLink?: string;
   postLink?: string;
+  excalidrawLink?: string;
   speakers?: string[];
   tags?: string[];
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 📚 Description

Adds optional Excalidraw links to event frontmatter and renders an `Abrir Excalidraw` button on past event detail pages when present, using the same visual style as the other event resource links.

Demo: https://cursor.com/artifacts/v/art-e98891c7-2375-4bd9-85d7-5331b8c5cdf3

<a href="https://cursor.com/agents/bc-1dea3bcf-fb6a-4053-95fc-6a1f8b75e001/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexcalidraw_review_comment_fix_demo.mp4"><img src="https://cursor.com/artifacts/c/art-878d5fe7-8b41-40da-84bc-4af7fdab2449" alt="excalidraw_review_comment_fix_demo.mp4" /></a>

![Aligned event resource buttons with matching Excalidraw style](https://cursor.com/artifacts/c/art-a48bc1c6-ca7c-4e2b-a120-3668b9f71674)

### 🔗 Linked issue

Resolves #795

### ❓ Type of change

- [x] ✨ New feature
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] ⚠️ Breaking change

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have performed a self-review of my code.
- [ ] I implemented tests for new features.
- [x] I tested the features already implemented.

### Verification

- `npm run build` passed and prerendered both DDIA event pages.
- Manual browser test confirmed both `Abrir Excalidraw` buttons open the requested Excalidraw boards.
- Manual browser test confirmed `Abrir Excalidraw` uses the same visual style as the adjacent resource buttons.
- PR review comments were checked and addressed by switching resource buttons to consistent flex-based layout/classes.
- `npm run lint` and `npx eslint .` are blocked by the repository's current lint tooling/configuration, unrelated to this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1dea3bcf-fb6a-4053-95fc-6a1f8b75e001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1dea3bcf-fb6a-4053-95fc-6a1f8b75e001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

