### PR TITLE
Fix event banner image paths for client-side navigation

### DIFF
--- a/src/components/EventDetailClient.tsx
+++ b/src/components/EventDetailClient.tsx
@@ -21,6 +21,16 @@ export default function EventDetailClient({ event, nextEvents }: Props) {
   const today = new Date().toISOString().split('T')[0];
   const isToday = event.date === today;
 
+  // Banners are stored in `public/events/`. Frontmatter only holds the file
+  // name, so we resolve it to an absolute path. Otherwise the relative URL is
+  // resolved against the current page URL, which breaks on client-side
+  // navigation and 404s (see issue #796). Absolute/external URLs pass through.
+  const bannerSrc = event.banner
+    ? /^(https?:\/\/|\/)/.test(event.banner)
+      ? event.banner
+      : `/events/${event.banner}`
+    : undefined;
+
   const getCalendarUrl = (event: Event) => {
     const startDate = new Date(`${event.date}T${event.time.split('-')[0]}-03:00`);
     const endDate = new Date(`${event.date}T${event.time.split('-')[1]}-03:00`);
@@ -79,10 +89,10 @@ export default function EventDetailClient({ event, nextEvents }: Props) {
               <EventTags tags={event.tags} className="mb-6" />
             )}
 
-            {event.banner && (
+            {bannerSrc && (
               <div className="mb-8 rounded-lg overflow-hidden">
                 <Image
-                  src={event.banner}
+                  src={bannerSrc}
                   alt={`Banner para ${event.title}`}
                   width={800}
                   height={320}


### PR DESCRIPTION
### 📚 Description

This change fixes an issue where event banner images fail to load during client-side navigation and on 404 pages. The problem occurs because banner file names stored in frontmatter are resolved as relative URLs against the current page URL, which breaks when navigating between pages.

The fix resolves banner file names to absolute paths by prepending `/events/` to relative URLs, while preserving absolute and external URLs (those starting with `http://`, `https://`, or `/`).

### 🔗 Linked issue

Resolves #796

### ❓ Type of change

- [ ] ✨ New feature
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] ⚠️ Breaking change

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] I have performed a self-review of my code.
- [ ] I implemented tests for new features.
- [x] I tested the features already implemented.

https://claude.ai/code/session_019qutt4Maip3RWKdMn4k7xq