### PR TITLE
feat(blog): paginação no blog e nos tópicos (8 por página)

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,8 +1,7 @@
-import { getSortedPostsData } from '@/lib/posts';
-import Link from 'next/link';
-import TopicTags from '@/components/TopicTags';
+import { getPaginatedPosts } from '@/lib/posts';
 import { Metadata } from 'next';
-import ArrowIcon from '@/components/ArrowIcon';
+import PostCard from '@/components/PostCard';
+import Pagination from '@/components/Pagination';
 
 export const metadata: Metadata = {
   title: "Blog | Craft & Code Club",
@@ -19,7 +18,7 @@ export const metadata: Metadata = {
 };
 
 export default function BlogPage() {
-  const posts = getSortedPostsData();
+  const { posts, totalPages } = getPaginatedPosts(1);
 
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900">
@@ -32,33 +31,13 @@ export default function BlogPage() {
         </header>
 
         <div className="grid gap-8 md:grid-cols-2">
-          {posts.map((post) => {
-            return (
-              <article key={post.id} className="flex flex-col bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden hover:shadow-lg transition-shadow">
-                <div className="p-6">
-                  <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 mb-3">
-                    <time dateTime={post.date}>{new Date(post.date).toLocaleDateString('pt-BR')}</time>
-                  </div>
-                  <TopicTags topics={post.topics} />
-                  <Link href={`/posts/${encodeURIComponent(post.id)}`}>
-                    <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
-                      {post.title}
-                    </h2>
-                  </Link>
-                  <p className="text-gray-600 dark:text-gray-300 mb-4">{post.description}</p>
-                  <Link 
-                    href={`/posts/${encodeURIComponent(post.id)}`}
-                    className="inline-flex items-center text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
-                  >
-                    Ler mais
-                    <ArrowIcon />
-                  </Link>
-                </div>
-              </article>
-            );
-          })}
+          {posts.map((post) => (
+            <PostCard key={post.id} post={post} />
+          ))}
         </div>
+
+        <Pagination currentPage={1} totalPages={totalPages} basePath="/blog" />
       </div>
     </div>
   );
-} 
+}

--- a/src/app/blog/page/[page]/not-found.tsx
+++ b/src/app/blog/page/[page]/not-found.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+
+export default function BlogPaginatedNotFound() {
+  return (
+    <div className="min-h-screen bg-white dark:bg-gray-900 flex items-center justify-center px-4">
+      <div className="max-w-md w-full text-center">
+        <h1 className="text-6xl font-bold text-gray-900 dark:text-white mb-4">404</h1>
+        <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-6">Página não encontrada</h2>
+        <p className="text-gray-600 dark:text-gray-300 mb-8">
+          Esta página do blog não existe. Talvez você tenha passado da última página.
+        </p>
+        <Link
+          href="/blog"
+          className="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700"
+        >
+          Voltar para o Blog
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/blog/page/[page]/page.tsx
+++ b/src/app/blog/page/[page]/page.tsx
@@ -1,0 +1,69 @@
+import { getPaginatedPosts } from '@/lib/posts';
+import { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+import PostCard from '@/components/PostCard';
+import Pagination from '@/components/Pagination';
+
+type Props = {
+  params: Promise<{ page: string }>;
+};
+
+export function generateStaticParams() {
+  const { totalPages } = getPaginatedPosts(1);
+
+  // Pre-render every page. Page 1 redirects to the canonical /blog (see below);
+  // it is kept in the params so output: export always has at least one path.
+  return Array.from({ length: totalPages }, (_, i) => ({
+    page: String(i + 1),
+  }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { page } = await params;
+
+  return {
+    title: `Blog - Página ${page} | Craft & Code Club`,
+    description: "Artigos sobre engenharia de software, System Design, Algoritmos, Estruturas de dados, DDD, melhores práticas e aprendizados da comunidade.",
+  };
+}
+
+export default async function BlogPaginatedPage({ params }: Props) {
+  const { page } = await params;
+  const currentPage = parseInt(page, 10);
+
+  if (isNaN(currentPage) || currentPage < 1) {
+    notFound();
+  }
+
+  // Page 1 lives at the canonical /blog URL.
+  if (currentPage === 1) {
+    redirect('/blog');
+  }
+
+  const { posts, totalPages } = getPaginatedPosts(currentPage);
+
+  if (currentPage > totalPages) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-white dark:bg-gray-900">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <header className="mb-12">
+          <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">Blog</h1>
+          <p className="text-xl text-gray-600 dark:text-gray-300">
+            Página {currentPage} de {totalPages}
+          </p>
+        </header>
+
+        <div className="grid gap-8 md:grid-cols-2">
+          {posts.map((post) => (
+            <PostCard key={post.id} post={post} />
+          ))}
+        </div>
+
+        <Pagination currentPage={currentPage} totalPages={totalPages} basePath="/blog" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/topics/[topic]/page.tsx
+++ b/src/app/topics/[topic]/page.tsx
@@ -1,9 +1,9 @@
-import TopicTags from '@/components/TopicTags';
-import { getSortedPostsData } from '@/lib/posts';
+import { getPaginatedPostsByTopic } from '@/lib/posts';
 import { getSortedTopicList, getTopicBySlug } from '@/lib/topics';
-import escapeHtml from 'escape-html';
 import { Metadata } from 'next';
 import Link from 'next/link';
+import PostCard from '@/components/PostCard';
+import Pagination from '@/components/Pagination';
 
 interface Props {
   params: Promise<{ topic: string }>;
@@ -41,8 +41,7 @@ export default async function TopicPage({ params }: Props) {
   const resolvedParams = await params;
 
   const topic = getTopicBySlug(resolvedParams.topic);
-  const allPosts = getSortedPostsData();
-  const posts = allPosts.filter(post => post.topics.filter(filterTopic => filterTopic.key === topic.key).length > 0);
+  const { posts, totalPages } = getPaginatedPostsByTopic(topic.key, 1);
   const topicTitle = topic.name;
   const topicDescription = topic.description ?? `Artigos e recursos sobre ${topicTitle} da comunidade Craft & Code Club.`;
 
@@ -75,35 +74,15 @@ export default async function TopicPage({ params }: Props) {
             </Link>
           </div>
         ) : (
-          <div className="grid gap-8 md:grid-cols-2">
-            {posts.map((post) => {
-              return (
-                <article key={post.id} className="flex flex-col bg-white dark:bg-gray-800 rounded-lg shadow-xs border border-gray-200 dark:border-gray-700 overflow-hidden hover:shadow-lg transition-shadow">
-                  <div className="p-6">
-                    <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 mb-3">
-                      <time dateTime={post.date}>{new Date(post.date).toLocaleDateString('pt-BR')}</time>
-                    </div>
-                    <TopicTags topics={post.topics} />
-                    <Link href={`/posts/${escapeHtml(post.id)}`}>
-                      <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
-                        {post.title}
-                      </h2>
-                    </Link>
-                    <p className="text-gray-600 dark:text-gray-300 mb-4">{post.description}</p>
-                    <Link
-                      href={`/posts/${escapeHtml(post.id)}`}
-                      className="inline-flex items-center text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
-                    >
-                      Ler mais
-                      <svg className="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                      </svg>
-                    </Link>
-                  </div>
-                </article>
-              );
-            })}
-          </div>
+          <>
+            <div className="grid gap-8 md:grid-cols-2">
+              {posts.map((post) => (
+                <PostCard key={post.id} post={post} />
+              ))}
+            </div>
+
+            <Pagination currentPage={1} totalPages={totalPages} basePath={`/topics/${topic.slug}`} />
+          </>
         )}
       </div>
     </div>

--- a/src/app/topics/[topic]/page/[page]/not-found.tsx
+++ b/src/app/topics/[topic]/page/[page]/not-found.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+
+export default function TopicPaginatedNotFound() {
+  return (
+    <div className="min-h-screen bg-white dark:bg-gray-900 flex items-center justify-center px-4">
+      <div className="max-w-md w-full text-center">
+        <h1 className="text-6xl font-bold text-gray-900 dark:text-white mb-4">404</h1>
+        <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-6">Página não encontrada</h2>
+        <p className="text-gray-600 dark:text-gray-300 mb-8">
+          Esta página não existe. Talvez você tenha passado da última página deste tópico.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <Link
+            href="/topics"
+            className="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700"
+          >
+            Ver tópicos
+          </Link>
+          <Link
+            href="/blog"
+            className="inline-flex items-center justify-center px-5 py-3 border border-gray-300 dark:border-gray-700 text-base font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
+          >
+            Voltar para o Blog
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/topics/[topic]/page/[page]/page.tsx
+++ b/src/app/topics/[topic]/page/[page]/page.tsx
@@ -1,0 +1,89 @@
+import { getPaginatedPostsByTopic } from '@/lib/posts';
+import { getSortedTopicList, getTopicBySlug } from '@/lib/topics';
+import { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+import PostCard from '@/components/PostCard';
+import Pagination from '@/components/Pagination';
+
+interface Props {
+  params: Promise<{ topic: string; page: string }>;
+}
+
+export function generateStaticParams() {
+  const params: { topic: string; page: string }[] = [];
+
+  for (const topic of getSortedTopicList()) {
+    const { totalPages } = getPaginatedPostsByTopic(topic.key, 1);
+    // Pre-render every page. Page 1 redirects to /topics/[topic] (see below);
+    // it is kept in the params so output: export always has at least one path.
+    for (let page = 1; page <= totalPages; page++) {
+      params.push({ topic: topic.slug, page: String(page) });
+    }
+  }
+
+  return params;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { topic: topicSlug, page } = await params;
+  const topic = getTopicBySlug(topicSlug);
+  const topicTitle = topic.name;
+  const topicDescription = topic.description ?? `Artigos e recursos sobre ${topicTitle} da comunidade Craft & Code Club.`;
+
+  return {
+    title: `${topicTitle} - Página ${page} | Craft & Code Club`,
+    description: topicDescription,
+    openGraph: {
+      title: `${topicTitle} - Página ${page} | Craft & Code Club`,
+      description: topicDescription,
+    },
+    twitter: {
+      title: `${topicTitle} - Página ${page} | Craft & Code Club`,
+      description: topicDescription,
+    }
+  };
+}
+
+export default async function TopicPaginatedPage({ params }: Props) {
+  const { topic: topicSlug, page } = await params;
+  const currentPage = parseInt(page, 10);
+
+  if (isNaN(currentPage) || currentPage < 1) {
+    notFound();
+  }
+
+  // Page 1 lives at the canonical /topics/[topic] URL.
+  if (currentPage === 1) {
+    redirect(`/topics/${topicSlug}`);
+  }
+
+  const topic = getTopicBySlug(topicSlug);
+  const { posts, totalPages } = getPaginatedPostsByTopic(topic.key, currentPage);
+
+  if (currentPage > totalPages) {
+    notFound();
+  }
+
+  const topicTitle = topic.name;
+
+  return (
+    <div className="bg-white dark:bg-gray-900 mb-20">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <header className="mb-12">
+          <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">{topicTitle}</h1>
+          <p className="text-xl text-gray-600 dark:text-gray-300">
+            Página {currentPage} de {totalPages}
+          </p>
+        </header>
+
+        <div className="grid gap-8 md:grid-cols-2">
+          {posts.map((post) => (
+            <PostCard key={post.id} post={post} />
+          ))}
+        </div>
+
+        <Pagination currentPage={currentPage} totalPages={totalPages} basePath={`/topics/${topic.slug}`} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/topics/[topic]/page/[page]/page.tsx
+++ b/src/app/topics/[topic]/page/[page]/page.tsx
@@ -1,4 +1,4 @@
-import { getPaginatedPostsByTopic } from '@/lib/posts';
+import { getPaginatedPostsByTopic, getSortedPostsData, POSTS_PER_PAGE } from '@/lib/posts';
 import { getSortedTopicList, getTopicBySlug } from '@/lib/topics';
 import { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
@@ -12,8 +12,13 @@ interface Props {
 export function generateStaticParams() {
   const params: { topic: string; page: string }[] = [];
 
+  // Read/parse all posts once, then derive per-topic page counts in memory,
+  // instead of re-reading the whole posts directory for every topic.
+  const allPosts = getSortedPostsData();
+
   for (const topic of getSortedTopicList()) {
-    const { totalPages } = getPaginatedPostsByTopic(topic.key, 1);
+    const count = allPosts.filter((post) => post.topics.some((t) => t.key === topic.key)).length;
+    const totalPages = Math.max(1, Math.ceil(count / POSTS_PER_PAGE));
     // Pre-render every page. Page 1 redirects to /topics/[topic] (see below);
     // it is kept in the params so output: export always has at least one path.
     for (let page = 1; page <= totalPages; page++) {

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,85 @@
+import Link from 'next/link';
+
+interface Props {
+  currentPage: number;
+  totalPages: number;
+  // Base path of the listing. Page 1 lives at `basePath` (the canonical URL);
+  // subsequent pages live at `${basePath}/page/${n}`.
+  // e.g. basePath="/blog" -> "/blog", "/blog/page/2"
+  //      basePath="/topics/algoritmos" -> "/topics/algoritmos", "/topics/algoritmos/page/2"
+  basePath: string;
+}
+
+export default function Pagination({ currentPage, totalPages, basePath }: Props) {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const hrefFor = (page: number) => (page <= 1 ? basePath : `${basePath}/page/${page}`);
+
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+  // Show at most 5 page numbers, collapsing the rest into ellipses.
+  let pagesToShow: (number | string)[] = pages;
+  if (totalPages > 7) {
+    if (currentPage <= 3) {
+      pagesToShow = [...pages.slice(0, 5), '...', totalPages];
+    } else if (currentPage >= totalPages - 2) {
+      pagesToShow = [1, '...', ...pages.slice(totalPages - 5)];
+    } else {
+      pagesToShow = [1, '...', currentPage - 1, currentPage, currentPage + 1, '...', totalPages];
+    }
+  }
+
+  return (
+    <nav className="flex justify-center mt-12" aria-label="Paginação">
+      <ul className="flex items-center gap-1">
+        {currentPage > 1 && (
+          <li>
+            <Link
+              href={hrefFor(currentPage - 1)}
+              aria-label="Página anterior"
+              className="px-3 py-2 rounded-md border border-gray-300 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+            >
+              &laquo;
+            </Link>
+          </li>
+        )}
+
+        {pagesToShow.map((page, index) =>
+          page === '...' ? (
+            <li key={`ellipsis-${index}`} className="px-3 py-2 text-gray-600 dark:text-gray-400">
+              ...
+            </li>
+          ) : (
+            <li key={page}>
+              <Link
+                href={hrefFor(page as number)}
+                aria-current={currentPage === page ? 'page' : undefined}
+                className={`px-3 py-2 rounded-md ${
+                  currentPage === page
+                    ? 'bg-blue-600 text-white'
+                    : 'border border-gray-300 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'
+                }`}
+              >
+                {page}
+              </Link>
+            </li>
+          )
+        )}
+
+        {currentPage < totalPages && (
+          <li>
+            <Link
+              href={hrefFor(currentPage + 1)}
+              aria-label="Próxima página"
+              className="px-3 py-2 rounded-md border border-gray-300 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+            >
+              &raquo;
+            </Link>
+          </li>
+        )}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -14,7 +14,9 @@ export default function PostCard({ post }: Props) {
     <article className="flex flex-col bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden hover:shadow-lg transition-shadow">
       <div className="p-6">
         <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 mb-3">
-          <time dateTime={post.date}>{new Date(post.date).toLocaleDateString('pt-BR')}</time>
+          <time dateTime={post.date}>
+            {new Date(post.date).toLocaleDateString('pt-BR', { timeZone: 'UTC' })}
+          </time>
         </div>
         <TopicTags topics={post.topics} />
         <Link href={href}>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,0 +1,36 @@
+import type { BlogPost } from '@/lib/posts';
+import Link from 'next/link';
+import ArrowIcon from './ArrowIcon';
+import TopicTags from './TopicTags';
+
+interface Props {
+  post: Omit<BlogPost, 'contentHtml'>;
+}
+
+export default function PostCard({ post }: Props) {
+  const href = `/posts/${encodeURIComponent(post.id)}`;
+
+  return (
+    <article className="flex flex-col bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden hover:shadow-lg transition-shadow">
+      <div className="p-6">
+        <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 mb-3">
+          <time dateTime={post.date}>{new Date(post.date).toLocaleDateString('pt-BR')}</time>
+        </div>
+        <TopicTags topics={post.topics} />
+        <Link href={href}>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
+            {post.title}
+          </h2>
+        </Link>
+        <p className="text-gray-600 dark:text-gray-300 mb-4">{post.description}</p>
+        <Link
+          href={href}
+          className="inline-flex items-center text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
+        >
+          Ler mais
+          <ArrowIcon />
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -63,6 +63,38 @@ export function getSortedPostsData(): Omit<BlogPost, 'contentHtml'>[] {
   });
 }
 
+export const POSTS_PER_PAGE = 8;
+
+export interface PaginatedPosts {
+  posts: Omit<BlogPost, 'contentHtml'>[];
+  total: number;
+  totalPages: number;
+}
+
+function paginatePosts(posts: Omit<BlogPost, 'contentHtml'>[], page: number, limit: number): PaginatedPosts {
+  const total = posts.length;
+  const totalPages = Math.ceil(total / limit);
+  const startIndex = (page - 1) * limit;
+
+  return {
+    posts: posts.slice(startIndex, startIndex + limit),
+    total,
+    totalPages,
+  };
+}
+
+export function getPaginatedPosts(page: number = 1, limit: number = POSTS_PER_PAGE): PaginatedPosts {
+  return paginatePosts(getSortedPostsData(), page, limit);
+}
+
+export function getPostsByTopic(topicKey: string): Omit<BlogPost, 'contentHtml'>[] {
+  return getSortedPostsData().filter((post) => post.topics.some((topic) => topic.key === topicKey));
+}
+
+export function getPaginatedPostsByTopic(topicKey: string, page: number = 1, limit: number = POSTS_PER_PAGE): PaginatedPosts {
+  return paginatePosts(getPostsByTopic(topicKey), page, limit);
+}
+
 export async function getPostData(id: string): Promise<BlogPost> {
   const fullPath = path.join(postsDirectory, `${id}.md`);
   const fileContents = fs.readFileSync(fullPath, 'utf8');

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -72,12 +72,17 @@ export interface PaginatedPosts {
 }
 
 function paginatePosts(posts: Omit<BlogPost, 'contentHtml'>[], page: number, limit: number): PaginatedPosts {
+  // Guard the public `limit` param: a non-positive value would make totalPages
+  // Infinity/NaN and blow up array allocation downstream.
+  const safeLimit = limit > 0 ? Math.floor(limit) : POSTS_PER_PAGE;
   const total = posts.length;
-  const totalPages = Math.ceil(total / limit);
-  const startIndex = (page - 1) * limit;
+  // An empty list is still "one (empty) page", so page 1 always exists and its
+  // canonical redirect keeps working under output: export.
+  const totalPages = Math.max(1, Math.ceil(total / safeLimit));
+  const startIndex = (page - 1) * safeLimit;
 
   return {
-    posts: posts.slice(startIndex, startIndex + limit),
+    posts: posts.slice(startIndex, startIndex + safeLimit),
     total,
     totalPages,
   };


### PR DESCRIPTION
## O que muda

Adiciona **paginação de 8 itens por página** nas listagens de posts, seguindo o mesmo modelo da listagem de eventos (`/events/past/[page]`):

- **Listagem geral** (`/blog`): página 1 na URL canônica; páginas seguintes em `/blog/page/[page]`.
- **Listagem por tópico/tag** (`/topics/[topic]`): página 1 na URL canônica; páginas seguintes em `/topics/[topic]/page/[page]`.

## Como foi feito

- **`lib/posts.ts`**: novas funções `getPaginatedPosts(page, 8)` e `getPaginatedPostsByTopic(topicKey, page, 8)` (espelhando `getPaginatedPastEvents`), retornando `{ posts, total, totalPages }`.
- **`components/Pagination.tsx`**: componente reutilizável (extraído/generalizado da paginação inline dos eventos). Recebe `basePath`; página 1 aponta para a URL canônica e as demais para `${basePath}/page/${n}`. Com ellipsis (`…`) quando há muitas páginas e atributos de acessibilidade (`aria-current`, `aria-label`).
- **`components/PostCard.tsx`**: card de post extraído para não duplicar o markup do artigo entre `/blog`, `/topics/[topic]` e as rotas paginadas.
- **Rotas paginadas**: `/blog/page/[page]` e `/topics/[topic]/page/[page]`, cada uma com `generateStaticParams`, `generateMetadata`, `notFound` e um `not-found.tsx` dedicado (como os eventos).

### Detalhe do `output: export`
A página 1 vive na URL canônica (`/blog`, `/topics/[topic]`). As rotas `[page]` pré-renderizam `1..totalPages` e **redirecionam `/page/1` para a base** (`redirect()`, mesmo mecanismo `NEXT_REDIRECT;replace` que os eventos já usam em `/events/past`). Isso evita conteúdo duplicado e garante que `generateStaticParams` nunca retorne array vazio — o que o `output: export` não permite.

## Estado atual dos dados
- 14 posts → `/blog` tem **2 páginas** (8 + 6).
- Nenhum tópico passa de 8 posts hoje, então a paginação por tópico ainda não aparece (fica escondida quando há 1 página só), mas a estrutura já está pronta e testada.

## Validação
- `tsc --noEmit`: limpo.
- `next build` (export estático): 133 páginas geradas, sem erros.
- HTML exportado conferido: `/blog` = 8 cards + nav de paginação; `/blog/page/2` = 6 cards; `/blog/page/1` e `/topics/[topic]/page/1` redirecionam para a base; `/topics/algoritmos` = 8 cards sem paginação (correto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)