### PR TITLE
feat(discord): centraliza o convite do Discord em uma página /join

### DIFF
--- a/.claude/skills/validacao-visual/SKILL.md
+++ b/.claude/skills/validacao-visual/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: validacao-visual
+description: Validação visual e manual de páginas do blog com o agent-browser CLI, em janela visível. Use quando precisar VER uma página renderizada (layout, quebra de texto, contraste, tema claro/escuro, viewport mobile), conferir hrefs no DOM já hidratado, ou capturar screenshots para revisão. Não use para teste automatizado de regressão, que é papel do Playwright em tests/e2e.
+allowed-tools: Bash(agent-browser:*), Bash(npm run dev:*), Bash(curl:*)
+---
+
+# Validação visual com agent-browser
+
+Complemento ao Playwright, não substituto.
+
+| | Playwright (`tests/e2e/`) | agent-browser |
+|---|---|---|
+| Papel | regressão automatizada, roda em CI | inspeção pontual, durante o desenvolvimento |
+| Responde | "continua passando?" | "como está ficando?" |
+| Pega | link errado, noindex sumindo, rota quebrada | quebra de linha feia, contraste ruim, espaçamento torto |
+
+Achado que motivou esta skill: o título `Engenharia de software de alto nível` quebrava deixando um "de" órfão no fim da linha. Os 45 testes passavam. Só olhando a tela dava para ver.
+
+**Nunca porte teste automatizado para cá.** Se a checagem deve rodar sempre, ela pertence a `tests/e2e/`.
+
+## Setup
+
+```bash
+npm install -g agent-browser
+agent-browser install          # baixa o Chrome
+```
+
+## Fluxo
+
+O servidor de dev precisa estar no ar (`npm run dev`, porta 3000).
+
+```bash
+agent-browser open http://localhost:3000/join --headed   # janela visível
+agent-browser snapshot -i -u                             # elementos + hrefs
+agent-browser click @e3                                  # age nos refs
+agent-browser screenshot /tmp/pagina.png
+agent-browser close
+```
+
+O `--headed` só vale na primeira chamada da sessão; o browser fica vivo entre comandos. Sem ele, roda headless.
+
+Os refs (`@e1`, `@e2`) são reatribuídos a cada snapshot e ficam obsoletos assim que a página muda. Tire snapshot de novo antes de cada interação.
+
+## Receitas deste projeto
+
+**Higiene dos links de Discord.** O convite real só pode aparecer em `/join`; todo o resto aponta para lá. Ver [src/lib/discord.ts](../../../src/lib/discord.ts).
+
+```bash
+agent-browser open http://localhost:3000/join
+agent-browser eval "[...document.querySelectorAll('a')].map(a=>a.getAttribute('href')).filter(h=>/discord/i.test(h)).join(' | ')"
+# esperado: só https://discord.gg/<convite atual>
+```
+
+**Metadata de compartilhamento.** A `/join` é feita para ser compartilhada, então o card do link importa:
+
+```bash
+agent-browser eval "[...document.querySelectorAll('meta[property^=og]')].map(m=>m.getAttribute('property')+'='+m.content).join(' | ')"
+```
+
+**Tema claro/escuro.** O dark mode é por classe (`@variant dark (&:where(.dark, .dark *))` em `globals.css`), controlado pelo `next-themes`. Emular `prefers-color-scheme` não funciona. Alterne pelo botão do próprio site:
+
+```bash
+agent-browser snapshot -i | grep -i tema     # acha o ref do toggle
+agent-browser click @e10
+agent-browser eval "document.documentElement.className"   # confirma: light | dark
+```
+
+**Overflow no mobile.** O `resize` não existe na CLI (testado na 0.32.3). Meça direto:
+
+```bash
+agent-browser eval "document.documentElement.scrollWidth > document.documentElement.clientWidth"
+# esperado: false
+```
+
+**Texto renderizado, para conferir copy e ordem dos blocos:**
+
+```bash
+agent-browser eval "document.querySelector('main').innerText.replace(/\n+/g,' | ')"
+```
+
+## Ao terminar
+
+Olhe a screenshot de verdade. Frame em branco é falha de carregamento, não sucesso. E rode `npm run test:e2e` antes de abrir PR: o que você validou no olho não substitui a suíte.

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ next-env.d.ts
 .idea
 .idea/*
 .data
+
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/_content/events/book-club-ddia-chapter-1.md
+++ b/_content/events/book-club-ddia-chapter-1.md
@@ -8,7 +8,7 @@ type: "online"
 isLive: true
 youtubeTitle: "Clube do Livro DDIA: Capítulo 1 - Trade-offs em Arquitetura de Sistemas de Alta Escala"
 banner: "book-club-ddia.png"
-registrationLink: "https://discord.gg/cqF9THUfnN"
+registrationLink: "{{discord-link}}"
 recordingLink: "https://youtu.be/53TFZSe-IGw"
 postLink: "https://craftcodeclub.io/posts/ddia-trade-offs-arquitetura-de-sistemas"
 excalidrawLink: "https://link.excalidraw.com/l/ADMgGFVWISx/9G9VQCCv2rL"

--- a/_content/events/book-club-ddia-chapter-2-part1.md
+++ b/_content/events/book-club-ddia-chapter-2-part1.md
@@ -8,7 +8,7 @@ type: "online"
 isLive: true
 youtubeTitle: "Clube do Livro DDIA: Capítulo 2 - Definição de Requisitos Não Funcionais - Parte 1"
 banner: "book-club-ddia.png"
-registrationLink: "https://discord.gg/cqF9THUfnN"
+registrationLink: "{{discord-link}}"
 recordingLink: "https://youtube.com/live/1FyvJh315Xk"
 sessionLink: "https://us06web.zoom.us/j/81900343896"
 postLink: "https://craftcodeclub.io/posts/ddia-requisitos-nao-funcionais-parte-1"

--- a/_content/events/book-club-ddia-chapter-2-part1.md
+++ b/_content/events/book-club-ddia-chapter-2-part1.md
@@ -10,7 +10,6 @@ youtubeTitle: "Clube do Livro DDIA: Capítulo 2 - Definição de Requisitos Não
 banner: "book-club-ddia.png"
 registrationLink: "{{discord-link}}"
 recordingLink: "https://youtube.com/live/1FyvJh315Xk"
-sessionLink: "https://us06web.zoom.us/j/81900343896"
 postLink: "https://craftcodeclub.io/posts/ddia-requisitos-nao-funcionais-parte-1"
 excalidrawLink: "https://link.excalidraw.com/l/ADMgGFVWISx/1ncjQemuKVK"
 tags:

--- a/_content/events/book-club-ddia-chapter-2-part2.md
+++ b/_content/events/book-club-ddia-chapter-2-part2.md
@@ -10,7 +10,6 @@ youtubeTitle: "Clube do Livro DDIA: Capítulo 2 - Definição de Requisitos Não
 banner: "book-club-ddia.png"
 registrationLink: "{{discord-link}}"
 recordingLink: "https://youtube.com/live/YEmTPYwv5NY"
-sessionLink: "https://us06web.zoom.us/j/88382249800?pwd=YjBFJCuD084OsefOjQEdXVFtemWanw.1"
 postLink: "https://craftcodeclub.io/posts/ddia-requisitos-nao-funcionais-parte-2"
 excalidrawLink: "https://app.excalidraw.com/s/ADMgGFVWISx/1ncjQemuKVK"
 tags:

--- a/_content/events/book-club-ddia-chapter-2-part2.md
+++ b/_content/events/book-club-ddia-chapter-2-part2.md
@@ -8,7 +8,7 @@ type: "online"
 isLive: true
 youtubeTitle: "Clube do Livro DDIA: Capítulo 2 - Definição de Requisitos Não Funcionais - Parte 2"
 banner: "book-club-ddia.png"
-registrationLink: "https://discord.gg/cqF9THUfnN"
+registrationLink: "{{discord-link}}"
 recordingLink: "https://youtube.com/live/YEmTPYwv5NY"
 sessionLink: "https://us06web.zoom.us/j/88382249800?pwd=YjBFJCuD084OsefOjQEdXVFtemWanw.1"
 postLink: "https://craftcodeclub.io/posts/ddia-requisitos-nao-funcionais-parte-2"

--- a/_content/events/book-club-ddia-chapter-3.md
+++ b/_content/events/book-club-ddia-chapter-3.md
@@ -9,7 +9,6 @@ isLive: true
 youtubeTitle: "Clube do Livro DDIA: Capítulo 3 - Data Models e Query Languages"
 banner: "book-club-ddia.png"
 registrationLink: "{{discord-link}}"
-sessionLink: "https://us06web.zoom.us/j/84753787873?pwd=N28Ni1L4zgIhK5PEfwVordIwQTDHen.1"
 tags:
   - "book-club"
   - "ddia"

--- a/_content/events/book-club-ddia-chapter-3.md
+++ b/_content/events/book-club-ddia-chapter-3.md
@@ -8,7 +8,7 @@ type: "online"
 isLive: true
 youtubeTitle: "Clube do Livro DDIA: Capítulo 3 - Data Models e Query Languages"
 banner: "book-club-ddia.png"
-registrationLink: "https://discord.gg/cqF9THUfnN"
+registrationLink: "{{discord-link}}"
 sessionLink: "https://us06web.zoom.us/j/84753787873?pwd=N28Ni1L4zgIhK5PEfwVordIwQTDHen.1"
 tags:
   - "book-club"

--- a/_content/posts/dsa-dijkstra.md
+++ b/_content/posts/dsa-dijkstra.md
@@ -345,4 +345,4 @@ Junte-se à nossa comunidade para aprender mais sobre algoritmos, estruturas de 
 Compartilhe conhecimento, participe de discussões e expanda suas habilidades junto a outros entusiastas da tecnologia. \
 Estamos esperando por você!
 
-[Link para a comunidade no discord](https://discord.gg/cqF9THUfnN)
+[Link para a comunidade no discord]({{discord-link}})

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,17 @@ const eslintConfig = [
   ...coreWebVitals,
   ...typescript,
   {
-    ignores: [".next/**", "out/**", "node_modules/**", "next-env.d.ts"],
+    ignores: [
+      ".next/**",
+      "out/**",
+      "node_modules/**",
+      "next-env.d.ts",
+      // Worktrees do Claude Code são cópias de trabalho com o próprio
+      // eslint.config.mjs (e as próprias deps). Lintar daqui quebra a execução.
+      ".claude/**",
+      "playwright-report/**",
+      "test-results/**",
+    ],
   },
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.3.3",
         "@types/escape-html": "^1.0.4",
         "@types/js-yaml": "^4.0.9",
@@ -1813,6 +1814,22 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1962,9 +1979,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1982,9 +1996,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2002,9 +2013,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2022,9 +2030,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6712,9 +6717,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6736,9 +6738,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6760,9 +6759,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6784,9 +6780,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8282,6 +8275,53 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/points-on-curve": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@next/third-parties": "16.2.10",
@@ -30,6 +33,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/escape-html": "^1.0.4",
     "@types/js-yaml": "^4.0.9",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = Number(process.env.PLAYWRIGHT_PORT ?? 3000);
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : [['list']],
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  // Sobe o dev server sozinho. Se você já tiver um rodando na porta, ele é
+  // reaproveitado (menos em CI, onde queremos sempre um servidor limpo).
+  webServer: {
+    command: `npm run dev -- --port ${PORT}`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,3 +1,6 @@
+import Link from 'next/link';
+import { DISCORD_PAGE_PATH } from '@/lib/discord';
+
 export default function AboutPage() {
   return (
     <div className="bg-white dark:bg-gray-900 mb-20">
@@ -44,14 +47,12 @@ export default function AboutPage() {
               Junte-se a nós para fazer parte de uma comunidade vibrante de desenvolvedores apaixonados por qualidade e artesanato de software.
             </p>
             <div className="flex flex-col sm:flex-row gap-4">
-              <a
-                href="https://discord.gg/cqF9THUfnN"
-                target="_blank"
-                rel="noopener noreferrer"
+              <Link
+                href={DISCORD_PAGE_PATH}
                 className="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors no-underline"
               >
                 Entrar no Discord
-              </a>
+              </Link>
             </div>
           </section>
         </div>

--- a/src/app/book-clubs/designing-data-intensive-applications/page.tsx
+++ b/src/app/book-clubs/designing-data-intensive-applications/page.tsx
@@ -2,9 +2,10 @@ import BookClubEventsClient from "@/components/BookClubEventsClient";
 import { getEventsByTags } from "@/lib/events";
 import { Metadata } from "next";
 import Image from "next/image";
+import Link from "next/link";
+import { DISCORD_PAGE_PATH } from "@/lib/discord";
 
 const BOOK_CLUB_TAGS = ["book-club", "ddia"];
-const DISCORD_INVITE = "https://discord.gg/cqF9THUfnN";
 
 export const metadata: Metadata = {
   title: "Book Club: Designing Data-Intensive Applications | Craft & Code Club",
@@ -185,17 +186,15 @@ export default async function BookClubPage() {
             rola no Discord da comunidade. Entre para acompanhar os capítulos,
             tirar dúvidas e não perder nenhum encontro.
           </p>
-          <a
-            href={DISCORD_INVITE}
-            target="_blank"
-            rel="noopener noreferrer"
+          <Link
+            href={DISCORD_PAGE_PATH}
             className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-md bg-white text-blue-700 font-medium hover:bg-blue-50 transition-colors"
           >
             <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
               <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z" />
             </svg>
             Entrar no Discord da comunidade
-          </a>
+          </Link>
         </section>
 
         {/* Encontros */}

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -1,0 +1,117 @@
+import type { Metadata } from 'next';
+import Image from 'next/image';
+import Link from 'next/link';
+import { DISCORD_INVITE_URL } from '@/lib/discord';
+
+const TITLE = 'Entrar no Discord | Craft & Code Club';
+const DESCRIPTION =
+  'Convite oficial para o servidor Discord do Craft & Code Club, comunidade de engenharia de software de alto nível. Clube do livro, papos técnicos, workshops, algoritmos e system design.';
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: {
+    canonical: '/join',
+  },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    images: ['/logo.png'],
+  },
+  twitter: {
+    title: TITLE,
+    description: DESCRIPTION,
+    images: ['/logo.png'],
+  },
+};
+
+const TAGS = [
+  'Clube do Livro',
+  'Papos Técnicos',
+  'Workshops',
+  'Algoritmos',
+  'System Design',
+  'AI',
+  'Spec-Driven Development',
+  'Engenharia de Software',
+  'Alta Performance',
+];
+
+function DiscordLogo({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z" />
+    </svg>
+  );
+}
+
+export default function JoinPage() {
+  return (
+    <div className="min-h-screen bg-linear-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800 flex items-center justify-center px-4 sm:px-6 lg:px-8 py-16">
+      <div className="w-full max-w-2xl text-center">
+        {/* Logos: Discord + comunidade */}
+        <div className="flex items-center justify-center gap-5 sm:gap-6">
+          <div className="flex h-20 w-20 items-center justify-center rounded-2xl bg-[#5865F2] shadow-lg shadow-[#5865F2]/30">
+            <DiscordLogo className="h-11 w-11 text-white" />
+          </div>
+
+          <span className="text-2xl font-light text-gray-300 dark:text-gray-600" aria-hidden="true">
+            +
+          </span>
+
+          <div className="flex h-20 w-20 items-center justify-center rounded-2xl bg-white dark:bg-gray-800 shadow-lg shadow-gray-900/10 dark:shadow-black/30">
+            <Image
+              src="/logo.png"
+              alt="Logo do Craft & Code Club"
+              width={56}
+              height={56}
+              priority
+            />
+          </div>
+        </div>
+
+        <h1 className="mt-8 text-balance text-lg font-medium text-blue-600 dark:text-blue-400 sm:text-xl">
+          Engenharia de software de alto nível
+        </h1>
+
+        <a
+          href={DISCORD_INVITE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-8 inline-flex items-center justify-center gap-3 rounded-xl bg-[#5865F2] px-10 py-4 text-lg font-semibold text-white shadow-lg shadow-[#5865F2]/30 hover:bg-[#4752C4] hover:shadow-xl hover:shadow-[#5865F2]/40 transition-all"
+        >
+          <DiscordLogo className="h-6 w-6" />
+          Entrar no Discord
+        </a>
+
+        <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+          Ao entrar, você concorda em seguir as{' '}
+          <Link
+            href="/codigo-conduta"
+            className="underline underline-offset-2 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+          >
+            regras da comunidade
+          </Link>
+          .
+        </p>
+
+        <p className="mt-12 mx-auto max-w-xl text-base text-gray-600 dark:text-gray-300 sm:text-lg">
+          Um espaço colaborativo para engenheiros de software aprenderem, trocarem
+          conhecimento e evoluírem juntos. Da base, com algoritmos e estruturas de dados,
+          até arquitetura de sistemas de alta performance.
+        </p>
+
+        <div className="mt-6 flex flex-wrap justify-center gap-2">
+          {TAGS.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 px-4 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-200"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import MermaidInitializer from '@/components/MermaidInitializer';
 import { NavLinks } from "@/components/NavLinks";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import { SITE_URL } from "@/lib/site";
+import { DISCORD_PAGE_PATH } from "@/lib/discord";
 import { GoogleTagManager } from '@next/third-parties/google';
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
@@ -12,6 +14,9 @@ import "./globals.css";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
+  // Sem isto, as imagens de Open Graph e Twitter resolvem para localhost e o
+  // card do link quebra ao compartilhar. Mesma origem usada pelo sitemap.
+  metadataBase: new URL(SITE_URL),
   title: "Comunidade Craft & Code Club",
   description: "Mergulhe em Algoritmos, Estruturas de Dados, System Design, DDD e Tópicos Avançados",
 };
@@ -71,12 +76,12 @@ export default function RootLayout({
                       <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
                     </svg>
                   </a>
-                  <a href="https://discord.gg/V7hQJZSDYu" target="_blank" rel="noopener noreferrer" className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300">
+                  <Link href={DISCORD_PAGE_PATH} className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300">
                     <span className="sr-only">Discord</span>
                     <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
                       <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"/>
                     </svg>
-                  </a>
+                  </Link>
                   <a href="http://www.youtube.com/@CraftCodeClub" target="_blank" rel="noopener noreferrer" className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300">
                     <span className="sr-only">YouTube</span>
                     <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
@@ -124,12 +129,12 @@ export default function RootLayout({
                         <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
                       </svg>
                     </a>
-                    <a href="https://discord.gg/cqF9THUfnN" target="_blank" rel="noopener noreferrer" className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300">
+                    <Link href={DISCORD_PAGE_PATH} className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300">
                       <span className="sr-only">Discord</span>
                       <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"/>
                       </svg>
-                    </a>
+                    </Link>
                     <a href="http://www.youtube.com/@CraftCodeClub" target="_blank" rel="noopener noreferrer" className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300">
                       <span className="sr-only">YouTube</span>
                       <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
@@ -160,12 +165,12 @@ export default function RootLayout({
                         <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
                       </svg>
                     </a>
-                    <a href="https://discord.gg/V7hQJZSDYu" target="_blank" rel="noopener noreferrer" className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300">
+                    <Link href={DISCORD_PAGE_PATH} className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300">
                       <span className="sr-only">Discord</span>
                       <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"/>
                       </svg>
-                    </a>
+                    </Link>
                     <a href="http://www.youtube.com/@CraftCodeClub" target="_blank" rel="noopener noreferrer" className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300">
                       <span className="sr-only">YouTube</span>
                       <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
@@ -195,9 +200,9 @@ export default function RootLayout({
                   <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Comunidade</h3>
                   <ul className="space-y-3">
                     <li>
-                      <a href="https://discord.gg/cqF9THUfnN" target="_blank" rel="noopener noreferrer" className="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
+                      <Link href={DISCORD_PAGE_PATH} className="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
                         Entrar no Discord
-                      </a>
+                      </Link>
                     </li>
                     <li>
                       <a href="http://www.youtube.com/@CraftCodeClub" target="_blank" rel="noopener noreferrer" className="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import ArrowIcon from "@/components/ArrowIcon";
 import TopicTags from "@/components/TopicTags";
 import UpcomingEventsHome from "@/components/UpcomingEventsHome";
 import { getEvents } from "@/lib/events";
+import { DISCORD_PAGE_PATH } from "@/lib/discord";
 import { getSortedPostsData } from "@/lib/posts";
 import escapeHtml from "escape-html";
 import Link from "next/link";
@@ -25,14 +26,12 @@ export default function Home() {
               Conhecimento da comunidade para a comunidade
             </p>
             <div className="mt-8 flex justify-center space-x-4">
-              <a
-                href="https://discord.gg/V7hQJZSDYu"
-                target="_blank"
-                rel="noopener noreferrer"
+              <Link
+                href={DISCORD_PAGE_PATH}
                 className="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 transition-colors"
               >
                 Entrar no Discord
-              </a>
+              </Link>
               <a
                 href="https://www.youtube.com/@CraftCodeClub"
                 target="_blank"

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,11 +2,12 @@ import { MetadataRoute } from 'next'
 import { getSortedPostsData } from '@/lib/posts'
 import { getEvents } from '@/lib/events'
 import { getSortedTopicList } from '@/lib/topics'
+import { SITE_URL } from '@/lib/site'
 
 export const dynamic = 'force-static'
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = process.env.SITE_URL || 'https://craftcodeclub.io'
+  const baseUrl = SITE_URL
   
   // Static routes
   const staticRoutes: MetadataRoute.Sitemap = [
@@ -39,6 +40,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.6,
+    },
+    {
+      url: `${baseUrl}/join`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
     },
     {
       url: `${baseUrl}/topics`,

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -2,6 +2,8 @@
 
 import type { Event } from "@/lib/events";
 import { getTodayInSaoPaulo } from "@/lib/date";
+import { DISCORD_PAGE_PATH } from "@/lib/discord";
+import { absoluteUrl } from "@/lib/site";
 import Image from "next/image";
 import Link from "next/link";
 import { useMemo } from "react";
@@ -34,9 +36,15 @@ export default function EventCard({
     const url = new URL("https://calendar.google.com/calendar/render");
     url.searchParams.append("action", "TEMPLATE");
     url.searchParams.append("text", event.title);
+    // O link vai para dentro de um convite de calendário, fora do site, então
+    // precisa ser absoluto. Sem `registrationLink` a descrição vai sem link, em
+    // vez de com um href="undefined".
+    const registrationUrl = event.registrationLink
+      ? absoluteUrl(event.registrationLink)
+      : null;
     url.searchParams.append(
       "details",
-      `${event.description}\n\n<a href="${event.registrationLink}">Link para o evento (${event.registrationLink})</a>`,
+      `${event.description}${registrationUrl ? `\n\n<a href="${registrationUrl}">Link para o evento (${registrationUrl})</a>` : ""}`,
     );
     url.searchParams.append("location", event.location);
     url.searchParams.append(
@@ -193,14 +201,12 @@ export default function EventCard({
               >
                 Participar Agora
               </a>
-              <a
-                href="https://discord.gg/cqF9THUfnN"
-                target="_blank"
-                rel="noopener noreferrer"
+              <Link
+                href={DISCORD_PAGE_PATH}
                 className="flex-1 flex items-center justify-center text-center px-4 py-2 rounded-md transition-colors bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 text-white"
               >
                 Entrar no Discord
-              </a>
+              </Link>
             </div>
           ) : hasYoutubeRegistrationLink ? (
             <div className="flex gap-3">
@@ -212,14 +218,12 @@ export default function EventCard({
               >
                 Agendar Lembrete
               </a>
-              <a
-                href="https://discord.gg/cqF9THUfnN"
-                target="_blank"
-                rel="noopener noreferrer"
+              <Link
+                href={DISCORD_PAGE_PATH}
                 className="flex-1 flex items-center justify-center text-center px-4 py-2 rounded-md transition-colors bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 text-white"
               >
                 Entrar no Discord
-              </a>
+              </Link>
             </div>
           ) : (
             <div className="flex gap-3">
@@ -231,14 +235,12 @@ export default function EventCard({
               >
                 Adicionar ao Calendário
               </a>
-              <a
-                href="https://discord.gg/cqF9THUfnN"
-                target="_blank"
-                rel="noopener noreferrer"
+              <Link
+                href={DISCORD_PAGE_PATH}
                 className="flex-1 flex items-center justify-center text-center px-4 py-2 rounded-md transition-colors bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 text-white"
               >
                 Entrar no Discord
-              </a>
+              </Link>
             </div>
           )}
         </div>

--- a/src/components/EventDetailClient.tsx
+++ b/src/components/EventDetailClient.tsx
@@ -2,7 +2,10 @@
 
 import type { Event } from '@/lib/events';
 import { getTodayInSaoPaulo } from '@/lib/date';
+import { DISCORD_PAGE_PATH } from '@/lib/discord';
+import { absoluteUrl } from '@/lib/site';
 import Image from 'next/image';
+import Link from 'next/link';
 import EventCard from "./EventCard";
 import EventTags from "./EventTags";
 
@@ -41,7 +44,7 @@ export default function EventDetailClient({ event, nextEvents }: Props) {
     url.searchParams.append('text', event.title);
     url.searchParams.append(
       'details',
-      `${event.description}${event.registrationLink ? `\n\n<a href="${event.registrationLink}">Link para o evento (${event.registrationLink})</a>` : ''}`
+      `${event.description}${event.registrationLink ? `\n\n<a href="${absoluteUrl(event.registrationLink)}">Link para o evento (${absoluteUrl(event.registrationLink)})</a>` : ''}`
     );
     url.searchParams.append('location', event.location);
     url.searchParams.append(
@@ -135,23 +138,19 @@ export default function EventDetailClient({ event, nextEvents }: Props) {
                       Participar Agora
                     </a>
                   ) : (
-                    <a
-                      href="https://discord.gg/cqF9THUfnN"
-                      target="_blank"
-                      rel="noopener noreferrer"
+                    <Link
+                      href={DISCORD_PAGE_PATH}
                       className="flex-1 flex items-center justify-center text-center px-4 py-2 rounded-md transition-colors bg-green-600 dark:bg-green-500 hover:bg-green-700 dark:hover:bg-green-600 text-white font-medium"
                     >
                       Participar via Discord
-                    </a>
+                    </Link>
                   )}
-                  <a
-                    href="https://discord.gg/cqF9THUfnN"
-                    target="_blank"
-                    rel="noopener noreferrer"
+                  <Link
+                    href={DISCORD_PAGE_PATH}
                     className="flex-1 flex items-center justify-center text-center px-4 py-2 rounded-md transition-colors bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 text-white"
                   >
                     Entrar no Discord
-                  </a>
+                  </Link>
                 </div>
               ) : new Date(event.date) > new Date() ? (
                 <div className="flex gap-3">
@@ -163,14 +162,12 @@ export default function EventDetailClient({ event, nextEvents }: Props) {
                   >
                     Adicionar ao Calendário
                   </a>
-                  <a
-                    href="https://discord.gg/cqF9THUfnN"
-                    target="_blank"
-                    rel="noopener noreferrer"
+                  <Link
+                    href={DISCORD_PAGE_PATH}
                     className="flex-1 flex items-center justify-center text-center px-4 py-2 rounded-md transition-colors bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600 text-white"
                   >
                     Entrar no Discord
-                  </a>
+                  </Link>
                 </div>
               ) : (
                 <div className="flex flex-col sm:flex-row gap-3">

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -1,0 +1,41 @@
+/**
+ * Convite oficial do Discord da comunidade.
+ *
+ * Este é o ÚNICO lugar do código onde o convite real aparece, e ele só é usado
+ * pela página `/join`. Para trocar o convite, revogue o link no Discord, gere um
+ * novo e atualize apenas a constante abaixo. Nenhum outro arquivo precisa mudar.
+ *
+ * Não use esta constante em outras páginas ou componentes: todo "Entrar no
+ * Discord" do site deve apontar para `DISCORD_PAGE_PATH`, para que continue
+ * existindo um único ponto de rotação.
+ */
+export const DISCORD_INVITE_URL = 'https://discord.gg/b5NnndAbFc';
+
+/**
+ * Caminho da página de convite. É para cá que todo link de Discord do site
+ * aponta, nunca direto para `discord.gg`.
+ */
+export const DISCORD_PAGE_PATH = '/join';
+
+/**
+ * Token para o conteúdo em markdown, onde não dá para importar constante.
+ * Use `{{discord-link}}` no lugar do link:
+ *
+ *     [Entre na comunidade]({{discord-link}})
+ *     registrationLink: "{{discord-link}}"
+ *
+ * É resolvido no build ao carregar posts e eventos. Assim o conteúdo não fica
+ * preso a para onde o link aponta hoje.
+ */
+export const DISCORD_LINK_TOKEN = '{{discord-link}}';
+
+/**
+ * Destino do token. Mudar aqui reescreve todo o conteúdo de uma vez, sem editar
+ * nenhum arquivo de markdown.
+ */
+export const DISCORD_LINK_TARGET: string = DISCORD_PAGE_PATH;
+
+/** Troca todas as ocorrências do token pelo destino atual. */
+export function resolveDiscordLinks(text: string): string {
+  return text.split(DISCORD_LINK_TOKEN).join(DISCORD_LINK_TARGET);
+}

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
+import { resolveDiscordLinks } from './discord';
 import { getTodayInSaoPaulo } from '@/lib/date';
 
 const eventsDirectory = path.join(process.cwd(), '_content', 'events');
@@ -34,7 +35,7 @@ export function getEvents(pastLimit?: number): EventsData {
     const id = fileName.replace(/\.md$/, '');
     const fullPath = path.join(eventsDirectory, fileName);
     const fileContents = fs.readFileSync(fullPath, 'utf8');
-    const matterResult = matter(fileContents);
+    const matterResult = matter(resolveDiscordLinks(fileContents));
 
     return {
       id,
@@ -95,7 +96,7 @@ export function getEvent(id: string): Event | null {
   try {
     const fullPath = path.join(eventsDirectory, `${id}.md`);
     const fileContents = fs.readFileSync(fullPath, 'utf8');
-    const matterResult = matter(fileContents);
+    const matterResult = matter(resolveDiscordLinks(fileContents));
 
     return {
       id,

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -11,6 +11,7 @@ import '../assets/code-stackoverflow-dark.css';
 import '../assets/inline-code.css';
 import rehypeSlug from 'rehype-slug';
 import { getTopicsMetadataAsDictionary, Topic } from './topics';
+import { resolveDiscordLinks } from './discord';
 
 const postsDirectory = path.join(process.cwd(), '_content', 'posts');
 
@@ -41,7 +42,7 @@ export function getSortedPostsData(): Omit<BlogPost, 'contentHtml'>[] {
     const fileContents = fs.readFileSync(fullPath, 'utf8');
 
     // Use gray-matter to parse the post metadata section
-    const { data } = matter(fileContents);
+    const { data } = matter(resolveDiscordLinks(fileContents));
 
     // Combine the data with the id
     return {
@@ -103,7 +104,7 @@ export function getPaginatedPostsByTopic(topicKey: string, page: number = 1, lim
 export async function getPostData(id: string): Promise<BlogPost> {
   const fullPath = path.join(postsDirectory, `${id}.md`);
   const fileContents = fs.readFileSync(fullPath, 'utf8');
-  const { data, content } = matter(fileContents);
+  const { data, content } = matter(resolveDiscordLinks(fileContents));
   const processedContent = await unified()
       .use(remarkParse)
       .use(remarkGfm)

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,12 @@
+/** Origem canônica do site. Mesma fonte usada pelo sitemap e pela metadata. */
+export const SITE_URL = process.env.SITE_URL || 'https://craftcodeclub.io';
+
+/**
+ * Transforma um caminho interno em URL absoluta, deixando URLs completas
+ * intactas. Necessário onde o link sai do site, como na descrição do evento de
+ * calendário, em que um `/join` relativo não resolveria.
+ */
+export function absoluteUrl(pathOrUrl: string): string {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(pathOrUrl)) return pathOrUrl;
+  return new URL(pathOrUrl, SITE_URL).toString();
+}

--- a/tests/e2e/discord-link-hygiene.spec.ts
+++ b/tests/e2e/discord-link-hygiene.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from '@playwright/test';
+import {
+  DISCORD_INVITE_URL,
+  DISCORD_LINK_TOKEN,
+  DISCORD_PAGE_PATH,
+  KEY_ROUTES,
+  extractHrefs,
+  fetchHtml,
+  gotoOk,
+  findRawInvites,
+  getSitemapPaths,
+  mapWithConcurrency,
+} from './helpers/site';
+
+/** Todas as rotas do sitemap menos a própria página de convite. */
+async function sweepablePaths(request: Parameters<typeof getSitemapPaths>[0]) {
+  const paths = await getSitemapPaths(request);
+  return paths.filter((path) => path !== DISCORD_PAGE_PATH);
+}
+
+/**
+ * O invariante: o convite do Discord existe em UM lugar só (a página /join).
+ * Todo o resto do site aponta para lá. Assim, trocar o convite é mudar uma
+ * constante, e nenhum link morto sobra espalhado pelo site.
+ */
+test.describe('higiene dos links de Discord', () => {
+  for (const route of KEY_ROUTES) {
+    test(`${route} não expõe convite cru do Discord`, async ({ request }) => {
+      const html = await fetchHtml(request, route);
+      const invites = findRawInvites(html);
+
+      expect(
+        invites,
+        `${route} deveria linkar para ${DISCORD_PAGE_PATH}, mas trouxe convite direto: ${invites.join(', ')}`,
+      ).toEqual([]);
+    });
+  }
+
+  for (const route of KEY_ROUTES) {
+    test(`${route} manda todo link de Discord para ${DISCORD_PAGE_PATH}`, async ({ page }) => {
+      await gotoOk(page, route);
+
+      const discordLinks = page.getByRole('link', { name: /discord/i });
+      const count = await discordLinks.count();
+      expect(count, `${route} não tem nenhum link de Discord`).toBeGreaterThan(0);
+
+      for (let i = 0; i < count; i++) {
+        const href = await discordLinks.nth(i).getAttribute('href');
+        expect(href, `link #${i} de ${route}`).toBe(DISCORD_PAGE_PATH);
+      }
+    });
+  }
+
+  test(`${DISCORD_PAGE_PATH} é a única página com o convite real`, async ({ request }) => {
+    const joinHtml = await fetchHtml(request, DISCORD_PAGE_PATH);
+    expect(findRawInvites(joinHtml)).toEqual([
+      DISCORD_INVITE_URL.replace(/^https?:\/\//, ''),
+    ]);
+  });
+
+  test('varredura completa: o token do markdown nunca vaza cru para a página', async ({
+    request,
+  }) => {
+    test.slow();
+
+    const paths = await getSitemapPaths(request);
+
+    const offenders = await mapWithConcurrency(paths, 4, async (path) => {
+      const html = await fetchHtml(request, path);
+      return html.includes(DISCORD_LINK_TOKEN) ? path : null;
+    });
+
+    expect(
+      offenders.filter(Boolean),
+      `${DISCORD_LINK_TOKEN} apareceu na página; a resolução no build não rodou`,
+    ).toEqual([]);
+  });
+
+  test('varredura completa: nenhuma página do sitemap tem convite cru', async ({ request }) => {
+    test.slow();
+
+    // A /join está no sitemap e é a dona legítima do convite; o teste acima já
+    // garante que ela carrega esse e só esse.
+    const paths = await sweepablePaths(request);
+    expect(paths.length, 'sitemap vazio, a varredura não testaria nada').toBeGreaterThan(10);
+
+    const offenders = await mapWithConcurrency(paths, 4, async (path) => {
+      const invites = findRawInvites(await fetchHtml(request, path));
+      return invites.length ? `${path} → ${invites.join(', ')}` : null;
+    });
+
+    expect(offenders.filter(Boolean)).toEqual([]);
+  });
+
+  test('varredura completa: todo href de discord aponta para a página de convite', async ({
+    request,
+  }) => {
+    test.slow();
+
+    const paths = await sweepablePaths(request);
+
+    const offenders = await mapWithConcurrency(paths, 4, async (path) => {
+      const bad = extractHrefs(await fetchHtml(request, path)).filter((href) =>
+        /discord/i.test(href) && href !== DISCORD_PAGE_PATH,
+      );
+      return bad.length ? `${path} → ${bad.join(', ')}` : null;
+    });
+
+    expect(offenders.filter(Boolean)).toEqual([]);
+  });
+});

--- a/tests/e2e/helpers/site.ts
+++ b/tests/e2e/helpers/site.ts
@@ -1,0 +1,110 @@
+import type { APIRequestContext, Page } from '@playwright/test';
+import { DISCORD_INVITE_URL, DISCORD_LINK_TOKEN, DISCORD_PAGE_PATH } from '../../../src/lib/discord';
+
+export { DISCORD_INVITE_URL, DISCORD_LINK_TOKEN, DISCORD_PAGE_PATH };
+
+/**
+ * Rotas representativas: cada uma exercita um componente diferente que já
+ * renderizou link de Discord em algum momento (hero da home, header/footer do
+ * layout, EventCard, EventDetailClient, CTA do book club, corpo de post em
+ * markdown). Se um convite cru voltar a aparecer no código, cai aqui.
+ */
+export const KEY_ROUTES = [
+  '/',
+  '/about',
+  '/blog',
+  '/events',
+  '/events/past',
+  '/events/book-club-ddia-chapter-1',
+  '/book-clubs/designing-data-intensive-applications',
+  '/posts/dsa-dijkstra',
+  '/codigo-conduta',
+  '/topics',
+  '/roadmap/dsa',
+] as const;
+
+/** Qualquer convite direto do Discord, não só o que está em uso hoje. */
+export const RAW_INVITE_PATTERN = /discord\.(gg|com\/invite)\/[A-Za-z0-9-]+/g;
+
+export function findRawInvites(html: string): string[] {
+  return [...new Set(html.match(RAW_INVITE_PATTERN) ?? [])];
+}
+
+/** Extrai os `href` de todos os `<a>` do HTML. */
+export function extractHrefs(html: string): string[] {
+  return [...html.matchAll(/<a\b[^>]*\bhref="([^"]*)"/g)].map((m) => m[1]);
+}
+
+/**
+ * Busca o HTML de uma rota. O dev server compila sob demanda, então a primeira
+ * requisição de uma rota pode responder 5xx enquanto o Turbopack ainda está
+ * montando o módulo, daí a retentativa. Erro 4xx é problema de verdade e
+ * estoura na hora.
+ */
+export async function fetchHtml(
+  request: APIRequestContext,
+  route: string,
+  attempts = 3,
+): Promise<string> {
+  let lastStatus = 0;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const response = await request.get(route);
+    if (response.ok()) {
+      return response.text();
+    }
+
+    lastStatus = response.status();
+    if (lastStatus < 500) break;
+
+    await new Promise((resolve) => setTimeout(resolve, 300 * attempt));
+  }
+
+  throw new Error(`GET ${route} respondeu ${lastStatus}`);
+}
+
+/**
+ * Navega e garante resposta 2xx. Mesmo motivo do retry acima: em dev, a
+ * primeira visita a uma rota pode pegar o Turbopack no meio da compilação.
+ */
+export async function gotoOk(page: Page, route: string, attempts = 3): Promise<void> {
+  let lastStatus = 0;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const response = await page.goto(route);
+    lastStatus = response?.status() ?? 0;
+
+    if (lastStatus >= 200 && lastStatus < 400) return;
+    if (lastStatus < 500) break;
+
+    await page.waitForTimeout(300 * attempt);
+  }
+
+  throw new Error(`Navegar para ${route} respondeu ${lastStatus}`);
+}
+
+/** Lê as <loc> do sitemap e devolve os caminhos (sem o domínio). */
+export async function getSitemapPaths(request: APIRequestContext): Promise<string[]> {
+  const xml = await fetchHtml(request, '/sitemap.xml');
+  return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => new URL(m[1]).pathname);
+}
+
+/** Roda `worker` sobre `items` com concorrência limitada. */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+
+  async function run() {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await worker(items[index]);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, run));
+  return results;
+}

--- a/tests/e2e/join-page.spec.ts
+++ b/tests/e2e/join-page.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test';
+import { DISCORD_INVITE_URL, DISCORD_PAGE_PATH, gotoOk } from './helpers/site';
+
+test.describe(`página de convite (${DISCORD_PAGE_PATH})`, () => {
+  // O header e o footer do site também trazem "Entrar no Discord" e a logo da
+  // comunidade, então tudo aqui é escopado ao <main> para mirar a página em si.
+  test.beforeEach(async ({ page }) => {
+    await gotoOk(page, DISCORD_PAGE_PATH);
+  });
+
+  test('carrega com o convite em destaque', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+
+    const cta = page.locator('main').getByRole('link', { name: /entrar no discord/i });
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute('href', DISCORD_INVITE_URL);
+  });
+
+  test('o CTA abre o Discord com rel seguro', async ({ page }) => {
+    const cta = page.locator('main').getByRole('link', { name: /entrar no discord/i });
+
+    await expect(cta).toHaveAttribute('target', '_blank');
+    const rel = (await cta.getAttribute('rel')) ?? '';
+    expect(rel).toContain('noopener');
+    expect(rel).toContain('noreferrer');
+  });
+
+  test('mostra a logo do Discord e a da comunidade', async ({ page }) => {
+    const main = page.locator('main');
+
+    await expect(main.getByAltText(/craft & code club/i)).toBeVisible();
+    // A logo do Discord é um <svg> inline dentro do bloco das duas marcas.
+    await expect(main.locator('svg').first()).toBeVisible();
+  });
+
+  test('aponta as regras da comunidade de forma discreta', async ({ page }) => {
+    const rules = page.locator('main').getByRole('link', { name: /regras da comunidade/i });
+    await expect(rules).toBeVisible();
+
+    await rules.click();
+    await expect(page).toHaveURL(/\/codigo-conduta$/);
+  });
+
+  test('declara canonical próprio', async ({ page }) => {
+    const canonical = await page.locator('link[rel="canonical"]').getAttribute('href');
+    expect(canonical).toMatch(new RegExp(`${DISCORD_PAGE_PATH}$`));
+  });
+
+  test('renderiza no mobile sem estourar a largura', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+
+    const overflows = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    );
+    expect(overflows, 'a página tem scroll horizontal no mobile').toBe(false);
+  });
+});

--- a/tests/e2e/private-links.spec.ts
+++ b/tests/e2e/private-links.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+import { fetchHtml, getSitemapPaths, mapWithConcurrency } from './helpers/site';
+
+/**
+ * Links de sala de reunião não podem sair no HTML público. Vale lembrar que o
+ * site é estático e os componentes recebem o objeto inteiro do evento: um campo
+ * novo no frontmatter acaba serializado no payload RSC embutido na página mesmo
+ * que nenhum componente o renderize. Foi assim que links de Zoom, com a senha no
+ * `?pwd=`, chegaram a páginas indexadas sem aparecer em lugar nenhum da UI.
+ *
+ * Divulgue sala em canal de membros, não no conteúdo do site.
+ */
+const MEETING_LINK_PATTERN =
+  /(?:[a-z0-9-]+\.)?(?:zoom\.us|meet\.google\.com|teams\.microsoft\.com|whereby\.com)\/[^\s"'<>\\]+/gi;
+
+test('nenhuma página pública expõe link de sala de reunião', async ({ request }) => {
+  test.slow();
+
+  const paths = await getSitemapPaths(request);
+
+  const offenders = await mapWithConcurrency(paths, 4, async (path) => {
+    const found = [...new Set((await fetchHtml(request, path)).match(MEETING_LINK_PATTERN) ?? [])];
+    return found.length ? `${path} → ${found.join(', ')}` : null;
+  });
+
+  expect(offenders.filter(Boolean)).toEqual([]);
+});

--- a/tests/e2e/seo.spec.ts
+++ b/tests/e2e/seo.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+import { DISCORD_PAGE_PATH, KEY_ROUTES, fetchHtml, getSitemapPaths } from './helpers/site';
+
+const INDEXABLE_ROUTES = [...KEY_ROUTES, DISCORD_PAGE_PATH];
+
+test.describe('indexação', () => {
+  test(`${DISCORD_PAGE_PATH} está no sitemap`, async ({ request }) => {
+    const paths = await getSitemapPaths(request);
+    expect(paths).toContain(DISCORD_PAGE_PATH);
+  });
+
+  test('o robots.txt não bloqueia a página de convite', async ({ request }) => {
+    const robots = await fetchHtml(request, '/robots.txt');
+
+    const disallows = [...robots.matchAll(/^Disallow:\s*(\S+)\s*$/gim)].map((m) => m[1]);
+    const blocking = disallows.filter((rule) => DISCORD_PAGE_PATH.startsWith(rule));
+
+    expect(blocking, `robots.txt bloqueia ${DISCORD_PAGE_PATH}`).toEqual([]);
+  });
+
+  test(`${DISCORD_PAGE_PATH} tem metadata pronta para compartilhamento`, async ({ request }) => {
+    // A página existe para ser compartilhada, então o card do link importa.
+    const html = await fetchHtml(request, DISCORD_PAGE_PATH);
+
+    expect(html).toMatch(/<meta property="og:title"/);
+    expect(html).toMatch(/<meta property="og:description"/);
+    expect(html).toMatch(/<meta property="og:image"/);
+  });
+
+  for (const route of INDEXABLE_ROUTES) {
+    test(`${route} é indexável`, async ({ request }) => {
+      const html = await fetchHtml(request, route);
+      const robotsMeta = html.match(/<meta name="robots" content="([^"]*)"/)?.[1] ?? '';
+
+      expect(robotsMeta, `${route} ganhou um noindex sem querer`).not.toContain('noindex');
+    });
+  }
+});


### PR DESCRIPTION
### 📚 Description

O convite do Discord estava duplicado em **18 lugares**: 13 links em 6 componentes e 5 arquivos de conteúdo markdown. Havia inclusive **dois códigos de convite diferentes** em circulação. Trocar o convite significava editar todos esses pontos, e qualquer esquecimento deixava um link morto.

Este PR cria a página **`/join`** como ponto único.

**Como funciona agora**

O convite vive em uma constante só, `src/lib/discord.ts`:

```ts
export const DISCORD_INVITE_URL = 'https://discord.gg/...';  // só a /join usa
export const DISCORD_PAGE_PATH  = '/join';                   // todo o resto usa
```

Todos os "Entrar no Discord" do site apontam para `/join`. Trocar o convite passa a ser **uma linha**, sem link morto em lugar nenhum.

**Token para o conteúdo markdown**

Markdown não importa constante, então o conteúdo usa um token:

```markdown
[Entre na comunidade]({{discord-link}})
registrationLink: "{{discord-link}}"
```

Resolvido no build ao carregar posts e eventos (`resolveDiscordLinks` em `src/lib/posts.ts` e `src/lib/events.ts`, aplicado antes do `gray-matter`, então cobre frontmatter e corpo de uma vez). Assim o conteúdo deixa de carregar a decisão de roteamento: mudar `DISCORD_LINK_TARGET` reescreve todos os links sem tocar em nenhum `.md`.

**Indexação e compartilhamento**

A página é indexável e feita para ser compartilhada: `canonical`, Open Graph, Twitter Card e entrada no sitemap.

Isso exigiu definir `metadataBase` no layout raiz. Sem ele, o `og:image` resolvia para `http://localhost:3000/logo.png`, ou seja, **o card de compartilhamento estava quebrado em toda página que declara um**, incluindo a do book club, que agora também foi corrigida.

**src/lib/site.ts**

Extrai a origem canônica, hoje repetida entre sitemap e metadata, e adiciona `absoluteUrl()`. O convite de calendário embute o `registrationLink` na descrição, onde um `/join` relativo não resolveria. No caminho, a descrição parou de emitir `href="undefined"` para eventos sem link de inscrição.

**Links de sala fora do conteúdo público**

Três eventos do book club tinham `sessionLink` no frontmatter, dois deles com a senha da sala embutida no `?pwd=`. Nenhum componente renderizava o campo, mas o site é exportado estático e os componentes recebem o objeto inteiro do evento, então o valor era serializado no payload RSC embutido na página e ia para o HTML de `/events`, da página do book club e de cada página de evento.

Os três foram removidos. Nada em `src/` lê `sessionLink`, então não há mudança de UI.

Entra também um teste que varre o sitemap atrás de links de sala (Zoom, Meet, Teams, Whereby), para que o próximo campo adicionado ao frontmatter não vaze do mesmo jeito. Verifiquei que ele falha: recolocando um link, o teste quebra e nomeia as três páginas.

**Testes**

Suíte Playwright em `tests/e2e/`, **48 testes**. O principal varre todas as URLs do sitemap e falha se alguma trouxer um `discord.gg` / `discord.com/invite` cru, um href de Discord que não seja `/join`, ou um `{{discord-link}}` não resolvido.

Confirmei que a suíte tem dentes: injetei um convite cru no `/about` e dois testes quebraram com a URL ofensora na mensagem.

```
✘ /about não expõe convite cru do Discord
  → /about deveria linkar para /join, mas trouxe convite direto: discord.gg/ConviteAntigo
```

Também entra uma skill (`.claude/skills/validacao-visual/`) documentando validação visual com o agent-browser CLI, para o que a suíte não pega. Ela nasceu de um caso real deste PR: o título quebrava deixando um "de" órfão no fim da linha, com todos os testes passando.

**Fora do escopo, mas encontrado no caminho**

O `npm run lint` está quebrado no `main`, independente deste PR. Confirmei com `git stash -u` + `npm ci` na árvore limpa. São dois problemas:

1. o eslint entrava em `.claude/worktrees/`, que tem config e deps próprias — **corrigido aqui**, via ignore;
2. `eslint-plugin-react` (aninhado no `eslint-config-next@16.2.10`) é incompatível com ESLint 10: `contextOrFilename.getFilename is not a function` — **não mexi**, é troca de versão de dependência e merece PR próprio.

O `npm run build` não é afetado.

### 🔗 Linked issue

<!-- sem issue associada -->

### ❓ Type of change

- [x] ✨ New feature
- [x] 👌 Enhancement (improving an existing functionality like performance)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have performed a self-review of my code.
- [x] I implemented tests for new features.
- [x] I tested the features already implemented.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HPLxPpSkWYYt8e5xksZ7i
