### PR TITLE
feat(events): add openSession field to event configuration

### DIFF
--- a/_content/events/book-club-ddia-chapter-3-part2.md
+++ b/_content/events/book-club-ddia-chapter-3-part2.md
@@ -6,6 +6,7 @@ time: "20:00-21:30"
 location: "Online via Zoom"
 type: "online"
 isLive: true
+openSession: true
 youtubeTitle: "Clube do Livro DDIA: Capítulo 3 - Data Models e Query Languages - Parte 2"
 banner: "book-club-ddia.png"
 registrationLink: "{{discord-link}}"

--- a/_content/events/roundtable-transaction-outbox-pattern.md
+++ b/_content/events/roundtable-transaction-outbox-pattern.md
@@ -5,6 +5,7 @@ date: "2026-07-25"
 time: "10:00-11:30"
 location: "Online via Zoom"
 type: "online"
+openSession: true
 registrationLink: "{{discord-link}}"
 banner: "roundtable-transaction-outbox-pattern.png"
 speakers:

--- a/docs/events.md
+++ b/docs/events.md
@@ -22,6 +22,7 @@ Campos suportados hoje:
 - `isLive` (boolean, opcional): campo extra (nao usado pelo site hoje); usado por automacoes externas (ex.: bot do Discord).
 - `youtubeTitle` (string, opcional): campo extra (nao usado pelo site hoje); usado por automacoes externas (ex.: bot do Discord).
 - `sessionLink` (string, opcional): campo extra (nao usado pelo site hoje); usado por automacoes externas (ex.: bot do Discord).
+- `openSession` (boolean, opcional): campo extra (nao usado pelo site hoje); usado por automacoes externas (ex.: bot do Discord). Quando `true`, indica que a sessao esta aberta a todos os participantes — o `sessionLink` sera publicado publicamente nas notificacoes do Discord para que qualquer pessoa possa entrar no palco/meeting/session. Quando omitido ou `false`, o `sessionLink` nao e publicado nas notificacoes (uso restrito a moderadores).
 
 Tags encontradas hoje em `_content/events/*.md`:
 
@@ -127,7 +128,8 @@ Notificacoes no canal de eventos
 - Janela de lembretes: 1 semana, 3 dias, 1 dia e 1 hora antes.
 - O embed inclui horarios em BR/CA/PT
 - Link de participacao no embed segue fallback:
-  - quando `sessionLink` existe, mostra o link de participacao em tempo real (exemplo: Zoom, Google Meet)
+  - quando `sessionLink` existe **e** `openSession: true`, publica o link de participacao em tempo real (exemplo: Zoom, Google Meet) — acessivel a todos
+  - quando `sessionLink` existe **e** `openSession` e omitido ou `false`, o link nao e publicado na notificacao (acesso restrito a moderadores)
   - quando `recordingLink` existe, mostra o link da live (exemplo: YouTube)
   - Mostra sempre o link de detalhes do evento no site (`https://craftcodeclub.io/events/<slug>`)
 


### PR DESCRIPTION
### 📚 Description

Added new property for discord.
`openSession` (boolean, opcional): campo extra (nao usado pelo site hoje); usado por automacoes externas (ex.: bot do Discord). Quando `true`, indica que a sessao esta aberta a todos os participantes — o `sessionLink` sera publicado publicamente nas notificacoes do Discord para que qualquer pessoa possa entrar no palco/meeting/session. Quando omitido ou `false`, o `sessionLink` nao e publicado nas notificacoes (uso restrito a moderadores).


### ❓ Type of change

- [ ] ✨ New feature
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] ⚠️ Breaking change


### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] I have performed a self-review of my code.
- [ ] I implemented tests for new features.
- [ ] I tested the features already implemented.
