### PR TITLE
Point Roadmap DSA links to external dsa.craftcodeclub.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,12 @@ Documentação completa de configuração de eventos:
 
 ### Roadmaps
 
-Os roadmaps são recursos de aprendizado estruturados que ajudam a comunidade a navegar por tópicos complexos de forma organizada. Atualmente, temos o **Roadmap de Algoritmos e Estruturas de Dados** disponível em `/roadmap/dsa`.
+Os roadmaps são recursos de aprendizado estruturados que ajudam a comunidade a navegar por tópicos complexos de forma organizada. Atualmente, temos o **Roadmap de Algoritmos e Estruturas de Dados**, hospedado em [dsa.craftcodeclub.io](https://dsa.craftcodeclub.io/).
 
 #### 📍 Acessando o Roadmap
 
-- **URL**: [https://craftcodeclub.io/roadmap/dsa](https://craftcodeclub.io/roadmap/dsa)
-- **Navegação**: Clique em "Roadmap DSA" no menu principal
+- **URL**: [https://dsa.craftcodeclub.io/](https://dsa.craftcodeclub.io/)
+- **Navegação**: Clique em "Roadmap DSA" no menu principal (abre em uma nova aba)
 
 #### ✏️ Editando o Roadmap
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -62,7 +62,7 @@ export default function Home() {
               <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-6 hover:shadow-lg transition-shadow">
                 <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">Algoritmos</h3>
                 <p className="text-gray-600 dark:text-gray-300 mb-4">Domine os fundamentos da ciência da computação e resolução de problemas.</p>
-                <Link href="/roadmap/dsa" aria-label="Saiba mais sobre Algoritmos" className="inline-flex items-center text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium">
+                <Link href="https://dsa.craftcodeclub.io/" target="_blank" rel="noopener noreferrer" aria-label="Saiba mais sobre Algoritmos" className="inline-flex items-center text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium">
                   Saiba mais <ArrowIcon />
                 </Link>
               </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -62,9 +62,9 @@ export default function Home() {
               <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-6 hover:shadow-lg transition-shadow">
                 <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">Algoritmos</h3>
                 <p className="text-gray-600 dark:text-gray-300 mb-4">Domine os fundamentos da ciência da computação e resolução de problemas.</p>
-                <Link href="https://dsa.craftcodeclub.io/" target="_blank" rel="noopener noreferrer" aria-label="Saiba mais sobre Algoritmos" className="inline-flex items-center text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium">
+                <a href="https://dsa.craftcodeclub.io/" target="_blank" rel="noopener noreferrer" aria-label="Saiba mais sobre Algoritmos" className="inline-flex items-center text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium">
                   Saiba mais <ArrowIcon />
-                </Link>
+                </a>
               </div>
               <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-6 hover:shadow-lg transition-shadow">
                 <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">System Design</h3>

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -3,14 +3,16 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-const links = [
+type NavLink = { href: string; label: string; external?: boolean };
+
+const links: NavLink[] = [
   { href: "/blog", label: "Blog" },
   { href: "/events", label: "Eventos" },
   {
     href: "/book-clubs/designing-data-intensive-applications",
     label: "Clube do Livro",
   },
-  { href: "/roadmap/dsa", label: "Roadmap DSA" },
+  { href: "https://dsa.craftcodeclub.io/", label: "Roadmap DSA", external: true },
   { href: "/about", label: "Sobre" },
 ];
 
@@ -28,8 +30,8 @@ export function NavLinks({
 
   return (
     <>
-      {links.map(({ href, label }) => {
-        const active = isActivePath(pathname, href);
+      {links.map(({ href, label, external }) => {
+        const active = !external && isActivePath(pathname, href);
 
         // Desktop: traço embaixo do texto. Mobile (menu vertical): barra à esquerda.
         const accent =
@@ -44,6 +46,8 @@ export function NavLinks({
             key={href}
             href={href}
             aria-current={active ? "page" : undefined}
+            target={external ? "_blank" : undefined}
+            rel={external ? "noopener noreferrer" : undefined}
             className={`font-medium transition-colors ${accent} ${state}`}
           >
             {label}

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -41,14 +41,29 @@ export function NavLinks({
           ? "text-blue-600 dark:text-blue-400 border-blue-600 dark:border-blue-400"
           : "text-gray-600 dark:text-gray-300 border-transparent hover:text-blue-600 dark:hover:text-blue-400";
 
+        const className = `font-medium transition-colors ${accent} ${state}`;
+
+        // Links externos usam <a> puro, como no resto do site (ex.: footer do layout).
+        if (external) {
+          return (
+            <a
+              key={href}
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={className}
+            >
+              {label}
+            </a>
+          );
+        }
+
         return (
           <Link
             key={href}
             href={href}
             aria-current={active ? "page" : undefined}
-            target={external ? "_blank" : undefined}
-            rel={external ? "noopener noreferrer" : undefined}
-            className={`font-medium transition-colors ${accent} ${state}`}
+            className={className}
           >
             {label}
           </Link>


### PR DESCRIPTION
## What

Redirect the user-facing **Roadmap DSA** links to the external site https://dsa.craftcodeclub.io/, opening in a new tab.

Two links updated:
- **Navbar** (`src/components/NavLinks.tsx`) — the "Roadmap DSA" nav item now points to the external URL with `target="_blank"` + `rel="noopener noreferrer"`. Added a small `NavLink` type with an `external` flag so the shared render loop knows to open external links in a new tab and skip active-route highlighting for them.
- **Homepage "Algoritmos" card** (`src/app/page.tsx`) — the "Saiba mais" link now points to the external URL and opens in a new tab.

## What's intentionally left unchanged

- The internal `/roadmap/dsa` page and its content files (`_content/roadmap/dsa.yml`, `src/app/roadmap/dsa/**`, components) are **kept as-is**, per the request ("for now keep the current roadmap files, just update the links").
- `src/app/sitemap.ts` still lists `/roadmap/dsa` — it's an SEO entry for the internal page, which still exists, not a user-facing navigation link.

## Verification

- `npx tsc --noEmit` passes clean.
- ESLint currently crashes on **any** file (`react/display-name` rule-loading `TypeError` under ESLint 10.7.0) — pre-existing/environmental, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UX7ZPyMFXS1nLWbocLn5gb