### PR TITLE
feat(apoiar): página Apoiar com CTA para a APOIA.se

### DIFF
--- a/src/app/apoiar/page.tsx
+++ b/src/app/apoiar/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from "next";
+import { ArrowRight, Heart } from "lucide-react";
+import { APOIA_URL, fetchSupporters } from "./supporters";
+
+const TITLE = "Apoiar a comunidade | Craft & Code Club";
+const DESCRIPTION =
+  "Ajude a manter o Craft & Code Club livre e aberto. Apoie o conteúdo, os eventos e as ferramentas da comunidade, e entre na lista de apoiadores.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: "/apoiar" },
+  openGraph: { title: TITLE, description: DESCRIPTION, images: ["/logo.png"] },
+  twitter: { title: TITLE, description: DESCRIPTION, images: ["/logo.png"] },
+};
+
+// Página estática: a lista de apoiadores é buscada na APOIA.se no build.
+export const dynamic = "force-static";
+
+const amberButton =
+  "inline-flex items-center gap-2 rounded-xl bg-amber-500 px-6 py-3 font-semibold text-white shadow-lg shadow-amber-500/30 hover:bg-amber-600 transition-colors";
+
+export default async function ApoiarPage() {
+  const supporters = await fetchSupporters();
+
+  return (
+    <div className="min-h-screen bg-linear-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800 px-4 sm:px-6 lg:px-8 py-16">
+      <div className="mx-auto max-w-3xl">
+        <span className="inline-block rounded-full border border-gray-200 dark:border-gray-700 bg-white/70 dark:bg-gray-800/70 px-4 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-300">
+          Feito pela comunidade, para a comunidade
+        </span>
+        <h1 className="mt-6 text-3xl sm:text-4xl font-bold tracking-tight text-gray-900 dark:text-white">
+          Apoie a comunidade
+        </h1>
+        <p className="mt-4 text-lg text-gray-600 dark:text-gray-300">
+          O <strong className="text-gray-900 dark:text-white">Craft &amp; Code Club</strong> é livre,
+          aberto e feito pela comunidade. O conteúdo, os eventos e as ferramentas se mantêm com o
+          apoio de pessoas e empresas que acreditam em educação de qualidade e gratuita para todo
+          mundo. Sem paywall, sem login e{" "}
+          <strong className="text-gray-900 dark:text-white">sem anúncios, nunca</strong>.
+        </p>
+
+        {/* Apoio principal: APOIA.se */}
+        <div className="mt-10 rounded-2xl border border-amber-300/60 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-500/10 p-6 sm:p-8">
+          <div className="flex items-center gap-2 font-semibold text-amber-700 dark:text-amber-400">
+            <Heart className="h-5 w-5" aria-hidden="true" />
+            Apoie a comunidade
+          </div>
+          <h2 className="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">Seja um apoiador</h2>
+          <p className="mt-2 max-w-prose text-gray-600 dark:text-gray-300">
+            Sua contribuição, do valor que você quiser, mantém o conteúdo saindo, os eventos
+            acontecendo e tudo livre e aberto para quem vem depois. E você entra na lista de
+            apoiadores abaixo.
+          </p>
+          <a href={APOIA_URL} target="_blank" rel="noopener noreferrer" className={`mt-5 ${amberButton}`}>
+            Quero apoiar
+            <ArrowRight className="h-4 w-4" aria-hidden="true" />
+          </a>
+        </div>
+
+        {/* Apoiadores (nomes trazidos da APOIA.se no build) */}
+        <section className="mt-12">
+          <div className="flex items-baseline justify-between gap-4 border-b border-gray-200 pb-3 dark:border-gray-700">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Apoiadores</h2>
+            <span className="text-sm text-gray-500 dark:text-gray-400">Pessoas que bancam a comunidade</span>
+          </div>
+          {supporters.length > 0 ? (
+            <div className="mt-5 flex flex-wrap gap-2">
+              {supporters.map((s) => (
+                <span
+                  key={s.name}
+                  className="rounded-full border border-gray-200 bg-white px-4 py-1.5 text-sm font-medium text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+                >
+                  {s.name}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <div className="mt-5 rounded-2xl border border-dashed border-gray-300 p-8 text-center dark:border-gray-600">
+              <p className="text-gray-600 dark:text-gray-300">
+                Ainda não há apoiadores por aqui.{" "}
+                <strong className="text-gray-900 dark:text-white">Seja o primeiro</strong>{" "}
+                a sustentar a comunidade Craft &amp; Code Club.
+              </p>
+              <a href={APOIA_URL} target="_blank" rel="noopener noreferrer" className={`mt-4 ${amberButton}`}>
+                Quero apoiar
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </a>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/apoiar/supporters.ts
+++ b/src/app/apoiar/supporters.ts
@@ -1,0 +1,119 @@
+// Apoiadores da comunidade, trazidos da APOIA.se em tempo de build (só o nome, do
+// apoio mais recente para o mais antigo). É o mesmo engine do Roadmap DSA.
+//
+// Sem as variáveis de ambiente, sem apoiadores ainda, ou em qualquer erro/timeout,
+// devolve lista vazia e a página /apoiar cai no convite "seja o primeiro". Nunca
+// quebra o build.
+//
+// Config (env local e secret no GitHub):
+//   APOIASE_TOKEN        token Bearer do painel da APOIA.se (dashboard)
+//   APOIASE_CAMPAIGN_ID  id numérico da campanha (ou o slug: craftcodeclub)
+//
+// É a mesma campanha do Roadmap DSA (mesma comunidade Craft & Code Club).
+
+export const APOIA_URL = "https://apoia.se/craftcodeclub";
+
+export type Supporter = { name: string };
+
+// Apoiadores que não vêm da APOIA.se (opcional). Aparecem primeiro na lista.
+const EXTRA_SUPPORTERS: Supporter[] = [];
+
+const API_BASE = "https://dashboard-api-v1.apoia.se/api/reports/backers";
+
+type Raw = Record<string, unknown>;
+
+function nestedName(v: unknown): string | undefined {
+  if (v && typeof v === "object") {
+    const n = (v as Raw).name ?? (v as Raw).nome;
+    if (typeof n === "string") return n;
+  }
+  return undefined;
+}
+
+// A API do painel não é versionada publicamente, então lemos o nome de forma
+// defensiva, tentando as chaves mais prováveis.
+function pickName(b: Raw): string | null {
+  const direct = [b.name, b.nome, b.backer_name, b.supporter_name, b.apoiador].find(
+    (v): v is string => typeof v === "string" && v.trim().length > 0
+  );
+  const s = (direct ?? nestedName(b.user) ?? nestedName(b.backer) ?? "").trim();
+  return s.length ? s : null;
+}
+
+// Timestamp do apoio, para ordenar do mais recente para o mais antigo.
+function pickTime(b: Raw): number {
+  const raw = [
+    b.status_changed_at,
+    b.statusChangedAt,
+    b.created_at,
+    b.createdAt,
+    b.subscribed_at,
+    b.first_support_at,
+    b.date,
+    b.updated_at,
+  ].find((v) => typeof v === "string" || typeof v === "number");
+  if (raw === undefined) return 0;
+  const t = Date.parse(String(raw));
+  return Number.isNaN(t) ? 0 : t;
+}
+
+// Sem status, assume ativo. Com status, descarta apoios claramente encerrados.
+function isActive(b: Raw): boolean {
+  const raw = [b.status, b.status_atual, b.support_status].find((v) => typeof v === "string");
+  const status = typeof raw === "string" ? raw.toLowerCase() : "";
+  if (!status) return true;
+  return !/cancel|inativ|inactive|expir|encerrad|refund|falh|failed/.test(status);
+}
+
+function toList(json: unknown): Raw[] {
+  if (Array.isArray(json)) return json as Raw[];
+  if (json && typeof json === "object") {
+    const o = json as Raw;
+    for (const key of ["backers", "data", "apoiadores", "results"]) {
+      if (Array.isArray(o[key])) return o[key] as Raw[];
+    }
+  }
+  return [];
+}
+
+export async function fetchSupporters(): Promise<Supporter[]> {
+  const token = process.env.APOIASE_TOKEN;
+  const campaign = process.env.APOIASE_CAMPAIGN_ID;
+  if (!token || !campaign) return [...EXTRA_SUPPORTERS];
+
+  try {
+    const res = await fetch(`${API_BASE}/${encodeURIComponent(campaign)}`, {
+      headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) {
+      console.warn(`[apoia.se] resposta HTTP ${res.status}. Mostrando placeholder de apoiadores.`);
+      return [...EXTRA_SUPPORTERS];
+    }
+
+    const raw = toList(await res.json());
+    const parsed = raw
+      .filter(isActive)
+      .map((b) => ({ name: pickName(b), t: pickTime(b) }))
+      .filter((b): b is { name: string; t: number } => b.name !== null)
+      .sort((a, b) => b.t - a.t); // mais recente primeiro
+
+    // Remove nomes repetidos, preservando a ordem (o mais recente prevalece).
+    const seen = new Set<string>();
+    const names: Supporter[] = [];
+    for (const b of parsed) {
+      const key = b.name.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      names.push({ name: b.name });
+    }
+
+    if (raw.length > 0 && names.length === 0) {
+      console.warn(`[apoia.se] recebeu ${raw.length} apoios mas não reconheceu os campos de nome. Ajuste pickName().`);
+    }
+    return [...EXTRA_SUPPORTERS, ...names];
+  } catch (err) {
+    console.warn("[apoia.se] falha ao buscar apoiadores. Mostrando placeholder.", err);
+    return [...EXTRA_SUPPORTERS];
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,7 +35,7 @@ export default function RootLayout({
           <nav className="sticky top-0 bg-white dark:bg-gray-800 shadow-xs z-50">
             <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
               {/* Mobile Header (Two Lines) */}
-              <div className="md:hidden">
+              <div className="min-[1100px]:hidden">
                 {/* First Line: Logo, Title, and Hamburger */}
                 <div className="flex items-center justify-between h-20">
                   <Link href="/" className="flex items-center space-x-3">
@@ -102,7 +102,7 @@ export default function RootLayout({
               </div>
 
               {/* Desktop Header */}
-              <div className="hidden md:flex items-center justify-between h-20">
+              <div className="hidden min-[1100px]:flex items-center justify-between h-20">
                 <Link href="/" className="flex items-center space-x-3">
                   <Image
                     src="/logo.png"
@@ -120,7 +120,7 @@ export default function RootLayout({
                   </div>
                 </Link>
 
-                <div className="flex items-center space-x-8">
+                <div className="flex items-center space-x-6">
                   <NavLinks />
                   <div className="flex items-center space-x-4">
                     <a href="https://github.com/craft-code-club" target="_blank" rel="noopener noreferrer" className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300">
@@ -218,6 +218,9 @@ export default function RootLayout({
                       <a href="https://github.com/craft-code-club" target="_blank" rel="noopener noreferrer" className="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
                         Contribuir no GitHub
                       </a>
+                    </li>
+                    <li>
+                      <Link href="/apoiar" className="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">Apoiar a comunidade</Link>
                     </li>
                     <li>
                       <Link href="/codigo-conduta" className="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">Código de Conduta</Link>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -48,6 +48,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
+      url: `${baseUrl}/apoiar`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
       url: `${baseUrl}/topics`,
       lastModified: new Date(),
       changeFrequency: 'weekly',

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-const links = [
+const links: { href: string; label: string; highlight?: boolean }[] = [
   { href: "/blog", label: "Blog" },
   { href: "/events", label: "Eventos" },
   {
@@ -12,7 +12,8 @@ const links = [
   },
   { href: "/roadmap/dsa", label: "Roadmap DSA" },
   { href: "/about", label: "Sobre" },
-  { href: "/apoiar", label: "Apoiar" },
+  // "Apoiar" é um CTA: fica destacado em âmbar para chamar atenção.
+  { href: "/apoiar", label: "Apoiar", highlight: true },
 ];
 
 // Ativo na própria rota e em qualquer sub-rota (ex.: /blog/algum-post destaca "Blog").
@@ -29,16 +30,21 @@ export function NavLinks({
 
   return (
     <>
-      {links.map(({ href, label }) => {
+      {links.map(({ href, label, highlight }) => {
         const active = isActivePath(pathname, href);
 
         // Desktop: traço embaixo do texto. Mobile (menu vertical): barra à esquerda.
         const accent =
           variant === "mobile" ? "border-l-2 pl-3" : "border-b-2 py-1";
 
-        const state = active
-          ? "text-blue-600 dark:text-blue-400 border-blue-600 dark:border-blue-400"
-          : "text-gray-600 dark:text-gray-300 border-transparent hover:text-blue-600 dark:hover:text-blue-400";
+        // "Apoiar" é destacado em âmbar (CTA), ativo ou não. Os demais seguem o azul.
+        const state = highlight
+          ? active
+            ? "text-amber-600 dark:text-amber-400 border-amber-500 dark:border-amber-400 font-semibold"
+            : "text-amber-600 dark:text-amber-400 border-transparent hover:text-amber-700 dark:hover:text-amber-300 font-semibold"
+          : active
+            ? "text-blue-600 dark:text-blue-400 border-blue-600 dark:border-blue-400"
+            : "text-gray-600 dark:text-gray-300 border-transparent hover:text-blue-600 dark:hover:text-blue-400";
 
         return (
           <Link

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -12,6 +12,7 @@ const links = [
   },
   { href: "/roadmap/dsa", label: "Roadmap DSA" },
   { href: "/about", label: "Sobre" },
+  { href: "/apoiar", label: "Apoiar" },
 ];
 
 // Ativo na própria rota e em qualquer sub-rota (ex.: /blog/algum-post destaca "Blog").
@@ -44,7 +45,7 @@ export function NavLinks({
             key={href}
             href={href}
             aria-current={active ? "page" : undefined}
-            className={`font-medium transition-colors ${accent} ${state}`}
+            className={`font-medium whitespace-nowrap transition-colors ${accent} ${state}`}
           >
             {label}
           </Link>

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -12,7 +12,7 @@ const links: { href: string; label: string; highlight?: boolean }[] = [
   },
   { href: "/roadmap/dsa", label: "Roadmap DSA" },
   { href: "/about", label: "Sobre" },
-  // "Apoiar" é um CTA: fica destacado em âmbar para chamar atenção.
+  // "Apoiar" é um CTA: fica destacado no azul do site para chamar atenção.
   { href: "/apoiar", label: "Apoiar", highlight: true },
 ];
 
@@ -37,11 +37,12 @@ export function NavLinks({
         const accent =
           variant === "mobile" ? "border-l-2 pl-3" : "border-b-2 py-1";
 
-        // "Apoiar" é destacado em âmbar (CTA), ativo ou não. Os demais seguem o azul.
+        // "Apoiar" é o CTA: usa o azul de destaque do site + negrito, ativo ou não.
+        // Os demais itens ficam cinza e só viram azul quando ativos.
         const state = highlight
           ? active
-            ? "text-amber-600 dark:text-amber-400 border-amber-500 dark:border-amber-400 font-semibold"
-            : "text-amber-600 dark:text-amber-400 border-transparent hover:text-amber-700 dark:hover:text-amber-300 font-semibold"
+            ? "text-blue-600 dark:text-blue-400 border-blue-600 dark:border-blue-400 font-semibold"
+            : "text-blue-600 dark:text-blue-400 border-transparent hover:text-blue-700 dark:hover:text-blue-300 font-semibold"
           : active
             ? "text-blue-600 dark:text-blue-400 border-blue-600 dark:border-blue-400"
             : "text-gray-600 dark:text-gray-300 border-transparent hover:text-blue-600 dark:hover:text-blue-400";

--- a/tests/e2e/apoiar-page.spec.ts
+++ b/tests/e2e/apoiar-page.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test';
+import { fetchHtml, getSitemapPaths, gotoOk } from './helpers/site';
+
+const APOIAR_PATH = '/apoiar';
+const APOIA_URL = 'https://apoia.se/craftcodeclub';
+
+test.describe(`página de apoio (${APOIAR_PATH})`, () => {
+  test(`${APOIAR_PATH} está no sitemap`, async ({ request }) => {
+    const paths = await getSitemapPaths(request);
+    expect(paths).toContain(APOIAR_PATH);
+  });
+
+  test(`${APOIAR_PATH} é indexável`, async ({ request }) => {
+    const html = await fetchHtml(request, APOIAR_PATH);
+    const robotsMeta = html.match(/<meta name="robots" content="([^"]*)"/)?.[1] ?? '';
+
+    expect(robotsMeta, `${APOIAR_PATH} ganhou um noindex sem querer`).not.toContain('noindex');
+  });
+
+  test('carrega (2xx) com o CTA de apoio em destaque', async ({ page }) => {
+    await gotoOk(page, APOIAR_PATH);
+
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+
+    // Há dois "Quero apoiar" (card principal e placeholder); o do topo é o principal.
+    const cta = page.locator('main').getByRole('link', { name: /quero apoiar/i }).first();
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute('href', APOIA_URL);
+  });
+
+  test('o CTA abre a APOIA.se com rel seguro', async ({ page }) => {
+    await gotoOk(page, APOIAR_PATH);
+
+    const cta = page.locator('main').getByRole('link', { name: /quero apoiar/i }).first();
+    await expect(cta).toHaveAttribute('target', '_blank');
+
+    const rel = (await cta.getAttribute('rel')) ?? '';
+    expect(rel).toContain('noopener');
+    expect(rel).toContain('noreferrer');
+  });
+
+  test('declara canonical próprio', async ({ page }) => {
+    await gotoOk(page, APOIAR_PATH);
+
+    const canonical = await page.locator('link[rel="canonical"]').getAttribute('href');
+    expect(canonical).toMatch(new RegExp(`${APOIAR_PATH}$`));
+  });
+
+  test('renderiza no mobile sem estourar a largura', async ({ page }) => {
+    await gotoOk(page, APOIAR_PATH);
+    await page.setViewportSize({ width: 375, height: 812 });
+
+    const overflows = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    );
+    expect(overflows, 'a página tem scroll horizontal no mobile').toBe(false);
+  });
+});


### PR DESCRIPTION
## O que muda

Adiciona a página **/apoiar** da comunidade Craft & Code Club:

- **Hero + CTA** apontando para a campanha na APOIA.se (`apoia.se/craftcodeclub`, a mesma do Roadmap DSA).
- **Mural de apoiadores**: os nomes são trazidos da APOIA.se **em tempo de build**, com o mesmo engine do Roadmap DSA (`fetchSupporters`, ordenado do apoio mais recente para o mais antigo). Sem os secrets ou sem apoiadores, mostra o convite "seja o primeiro". Nunca quebra o build.
- Página estática (`output: export`), no estilo do blog (Tailwind, tema claro/escuro).
- Link **"Apoiar"** no header (desktop e menu mobile) e **"Apoiar a comunidade"** no rodapé.
- Rota adicionada ao `sitemap`.

### Header responsivo
Com o item novo na navegação, o menu hambúrguer passou a aparecer a partir de **1100px** (antes 768px), para os itens não apertarem/quebrarem linha. Rótulos com `whitespace-nowrap`. Verificado de 390px a 1280px, sem overflow horizontal.

## Configuração (para os nomes aparecerem)
O build lê os secrets `APOIASE_TOKEN` e `APOIASE_CAMPAIGN_ID` (Settings → Secrets), a mesma campanha do Roadmap DSA. Sem eles, a página mostra o placeholder "seja o primeiro".

## Testes
- `npm run build` passa (lint + typecheck + export estático).
- Conferido visualmente em desktop e mobile, tema claro e escuro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VDrmjQEqCQJ1zkzHUxedu