### PR TITLE
fix(readme): point the Discord link to the /join page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ O Craft & Code Club é uma comunidade de desenvolvedores apaixonados por qualida
 
 ## :rocket: Faça parte da Comunidade
 
-Linkd para participar no Discord: \
-https://discord.gg/V7hQJZSDYu
+Link para participar no Discord: \
+https://craftcodeclub.io/join
 
 ## 📋 Usando este Template
 


### PR DESCRIPTION
## What changes

The README pointed at a raw invite, `discord.gg/V7hQJZSDYu`, which no longer matches the one `/join` actually serves. Anyone arriving from GitHub hit a stale link. It now points at `https://craftcodeclub.io/join`.

`src/lib/discord.ts` already spells out the invariant:

> This is the ONLY place in the code where the real invite appears, and it is used only by the `/join` page. [...] every "Join Discord" on the site should point at `DISCORD_PAGE_PATH`, so that a single rotation point keeps existing.

The README was the one spot still bypassing that, which is exactly how it drifted out of sync. With this change, rotating the invite stays a one-line edit in `src/lib/discord.ts`.

Also fixes the `Linkd` typo on the same line.

## Context

Found while auditing [craft-code-club/roadmap-dsa](https://github.com/craft-code-club/roadmap-dsa) before making it public, where the same convention was adopted: direct invite inside the app, `/join` in every doc and `.github/` template.

## Verification

Docs-only change, one line of link plus one typo. No code path touched, so `discord-link-hygiene.spec.ts` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sbvXuNEcwzG24MXUvQqnz